### PR TITLE
Update README.md with new device

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ https://singlekey-id.com/auth/connect/authorize?state=nKqS17oMAxqUsQpMznajIr&non
   - Buderus Logatherm WLW 186i heat pump with the MX300 communication module
 - **wddw2**
   - Hydronext 5700s with wifi module Bosch 7736505449
+- **IVT Aero Series**
 
 ***Users reported that Bosch Climate Class 3000i and 7000i based on Midea are not working.***
 
@@ -91,7 +92,7 @@ https://singlekey-id.com/auth/connect/authorize?state=nKqS17oMAxqUsQpMznajIr&non
 This integration has the following features:
 * Retrieve an authentication token based on username and password from singlekey-id.com
 * Refresh token if expired
-* The state of all entities are updated on each action and every 5 minutes.
+* The state of all entities are updated on each action and every 60 seconds.
 * Using pure async implementation for reduced load on the platform.
 * Read devices notifications
 


### PR DESCRIPTION
I just found out about this integration and tested it on my IVT Aero 807-1. I suggest adding this being supported to the README.md .  I think this should work on the whole Aero Series, but one could also be more conservative and only add the specific tested models.

It also looks like the default update interval is 60 seconds since 3 months ago, I checked the git history and it went from 4 min => 15 sec => 60 seconds. https://github.com/serbanb11/bosch-homecom-hass/blame/297d095c4c525cd8e7768447e397918d345f814f/custom_components/bosch_homecom/const.py#L12