### PR TITLE
Harden Bosch auth refresh and setup bootstrap

### DIFF
--- a/custom_components/bosch_homecom/__init__.py
+++ b/custom_components/bosch_homecom/__init__.py
@@ -5,18 +5,13 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import timedelta
+from typing import Any
 
 from aiohttp.client_exceptions import ClientConnectorError, ClientError
 from homecom_alt import (
     ApiError,
     AuthFailedError,
     ConnectionOptions,
-    HomeComAlt,
-    HomeComCommodule,
-    HomeComGeneric,
-    HomeComK40,
-    HomeComRac,
-    HomeComWddw2,
 )
 
 from homeassistant.config_entries import ConfigEntry
@@ -35,10 +30,18 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .const import (
     CONF_BRAND_BUDERUS,
     CONF_REFRESH,
-    DOMAIN,
-    MODEL,
     CONF_UPDATE_SECONDS,
     DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+    MODEL,
+)
+from .client import (
+    PersistentHomeComAlt as HomeComAlt,
+    PersistentHomeComCommodule as HomeComCommodule,
+    PersistentHomeComGeneric as HomeComGeneric,
+    PersistentHomeComK40 as HomeComK40,
+    PersistentHomeComRac as HomeComRac,
+    PersistentHomeComWddw2 as HomeComWddw2,
 )
 from .coordinator import (
     BoschComModuleCoordinatorCommodule,
@@ -66,7 +69,7 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up platform from a ConfigEntry."""
-    coordinators: list[any] = []
+    coordinators: list[Any] = []
     token: str | None = entry.data.get(CONF_TOKEN)
     refresh: str | None = entry.data.get(CONF_REFRESH)
 
@@ -82,9 +85,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return False
     websession = async_get_clientsession(hass)
 
-    bhc = await HomeComAlt.create(websession, options, True)
-
     try:
+        bhc = HomeComAlt(websession, options, True, hass, entry)
         devices = await bhc.async_get_devices()
     except (ApiError, ClientError, ClientConnectorError, TimeoutError) as err:
         raise ConfigEntryNotReady from err
@@ -134,7 +136,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 BoschComModuleCoordinatorRac(
                     hass,
                     HomeComRac(
-                        websession, coordinator_options, device_id, auth_provider
+                        websession,
+                        coordinator_options,
+                        device_id,
+                        auth_provider,
+                        hass,
+                        entry,
                     ),
                     device,
                     firmware,
@@ -147,7 +154,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 BoschComModuleCoordinatorK40(
                     hass,
                     HomeComK40(
-                        websession, coordinator_options, device_id, auth_provider
+                        websession,
+                        coordinator_options,
+                        device_id,
+                        auth_provider,
+                        hass,
+                        entry,
                     ),
                     device,
                     firmware,
@@ -160,7 +172,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 BoschComModuleCoordinatorWddw2(
                     hass,
                     HomeComWddw2(
-                        websession, coordinator_options, device_id, auth_provider
+                        websession,
+                        coordinator_options,
+                        device_id,
+                        auth_provider,
+                        hass,
+                        entry,
                     ),
                     device,
                     firmware,
@@ -173,7 +190,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 BoschComModuleCoordinatorCommodule(
                     hass,
                     HomeComCommodule(
-                        websession, coordinator_options, device_id, auth_provider
+                        websession,
+                        coordinator_options,
+                        device_id,
+                        auth_provider,
+                        hass,
+                        entry,
                     ),
                     device,
                     firmware,
@@ -186,7 +208,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 BoschComModuleCoordinatorGeneric(
                     hass,
                     HomeComGeneric(
-                        websession, coordinator_options, device_id, auth_provider
+                        websession,
+                        coordinator_options,
+                        device_id,
+                        auth_provider,
+                        hass,
+                        entry,
                     ),
                     device,
                     firmware,

--- a/custom_components/bosch_homecom/client.py
+++ b/custom_components/bosch_homecom/client.py
@@ -1,0 +1,159 @@
+"""Persistent HomeCom client wrappers."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_TOKEN
+from homeassistant.core import HomeAssistant
+from homecom_alt import (
+    ConnectionOptions,
+    HomeComAlt,
+    HomeComCommodule,
+    HomeComGeneric,
+    HomeComK40,
+    HomeComRac,
+    HomeComWddw2,
+)
+
+from .const import CONF_REFRESH
+
+
+class _PersistAuthMixin:
+    """Persist Bosch auth state whenever the client rotates credentials."""
+
+    def __init__(
+        self, hass: HomeAssistant, entry: ConfigEntry, options: ConnectionOptions
+    ) -> None:
+        """Store Home Assistant context for auth persistence."""
+        self._persist_hass = hass
+        self._persist_entry = entry
+        lock = getattr(options, "_auth_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            setattr(options, "_auth_lock", lock)
+        self._auth_lock: asyncio.Lock = lock
+
+    async def _async_persist_auth_state(self) -> None:
+        """Persist in-memory Bosch auth state if it diverges from entry storage."""
+        token = self.token
+        refresh = self.refresh_token
+        if not token or not refresh:
+            return
+
+        if (
+            self._persist_entry.data.get(CONF_TOKEN) == token
+            and self._persist_entry.data.get(CONF_REFRESH) == refresh
+        ):
+            return
+
+        new_data = dict(self._persist_entry.data)
+        new_data[CONF_TOKEN] = token
+        new_data[CONF_REFRESH] = refresh
+        self._persist_hass.config_entries.async_update_entry(
+            self._persist_entry, data=new_data
+        )
+
+    async def get_token(self) -> bool | None:
+        """Refresh Bosch auth and immediately sync rotated credentials to storage."""
+        async with self._auth_lock:
+            refreshed = await super().get_token()
+            await self._async_persist_auth_state()
+            return refreshed
+
+
+class PersistentHomeComAlt(_PersistAuthMixin, HomeComAlt):
+    """HomeCom bootstrap client with auth persistence."""
+
+    def __init__(
+        self,
+        session: Any,
+        options: ConnectionOptions,
+        auth_provider: bool,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+    ) -> None:
+        _PersistAuthMixin.__init__(self, hass, entry, options)
+        HomeComAlt.__init__(self, session, options, auth_provider)
+
+
+class PersistentHomeComGeneric(_PersistAuthMixin, HomeComGeneric):
+    """Generic Bosch client with auth persistence."""
+
+    def __init__(
+        self,
+        session: Any,
+        options: ConnectionOptions,
+        device_id: str,
+        auth_provider: bool,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+    ) -> None:
+        _PersistAuthMixin.__init__(self, hass, entry, options)
+        HomeComGeneric.__init__(self, session, options, device_id, auth_provider)
+
+
+class PersistentHomeComRac(_PersistAuthMixin, HomeComRac):
+    """RAC Bosch client with auth persistence."""
+
+    def __init__(
+        self,
+        session: Any,
+        options: ConnectionOptions,
+        device_id: str,
+        auth_provider: bool,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+    ) -> None:
+        _PersistAuthMixin.__init__(self, hass, entry, options)
+        HomeComRac.__init__(self, session, options, device_id, auth_provider)
+
+
+class PersistentHomeComK40(_PersistAuthMixin, HomeComK40):
+    """K40 Bosch client with auth persistence."""
+
+    def __init__(
+        self,
+        session: Any,
+        options: ConnectionOptions,
+        device_id: str,
+        auth_provider: bool,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+    ) -> None:
+        _PersistAuthMixin.__init__(self, hass, entry, options)
+        HomeComK40.__init__(self, session, options, device_id, auth_provider)
+
+
+class PersistentHomeComWddw2(_PersistAuthMixin, HomeComWddw2):
+    """WDDW2 Bosch client with auth persistence."""
+
+    def __init__(
+        self,
+        session: Any,
+        options: ConnectionOptions,
+        device_id: str,
+        auth_provider: bool,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+    ) -> None:
+        _PersistAuthMixin.__init__(self, hass, entry, options)
+        HomeComWddw2.__init__(self, session, options, device_id, auth_provider)
+
+
+class PersistentHomeComCommodule(_PersistAuthMixin, HomeComCommodule):
+    """Commodule Bosch client with auth persistence."""
+
+    def __init__(
+        self,
+        session: Any,
+        options: ConnectionOptions,
+        device_id: str,
+        auth_provider: bool,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+    ) -> None:
+        _PersistAuthMixin.__init__(self, hass, entry, options)
+        HomeComCommodule.__init__(self, session, options, device_id, auth_provider)

--- a/custom_components/bosch_homecom/config_flow.py
+++ b/custom_components/bosch_homecom/config_flow.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
-from dataclasses import dataclass
 import logging
 from typing import Any
 
@@ -36,20 +35,7 @@ from .const import (
     SINGLEKEY_LOGIN_URL_BUDERUS,
 )
 
-
-@dataclass
-class BhcConfig:
-    """HomeCom device configuration class."""
-
-    username: str
-    token: str
-    refresh_token: str
-    code: str
-
-
 _LOGGER = logging.getLogger(__name__)
-
-BRAND_OPTIONS = ["bosch", "buderus"]
 
 AUTH_SCHEMA = vol.Schema(
     {
@@ -117,9 +103,21 @@ class BoschHomecomConfigFlow(ConfigFlow, domain=DOMAIN):
                 # await async_check_credentials(self.hass, user_input)
             except (ApiError, AuthFailedError, ClientConnectorError, TimeoutError):
                 errors["base"] = "cannot_connect"
+                return self.async_show_form(
+                    step_id="browser",
+                    data_schema=BROWSER_AUTH_SCHEMA,
+                    description_placeholders={"url": login_url},
+                    errors=errors,
+                )
             except Exception:
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
+                return self.async_show_form(
+                    step_id="browser",
+                    data_schema=BROWSER_AUTH_SCHEMA,
+                    description_placeholders={"url": login_url},
+                    errors=errors,
+                )
 
             try:
                 devices = await bhc.async_get_devices()
@@ -177,11 +175,6 @@ class BoschHomecomConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self.data.update(user_input)
             self.data[CONF_DEVICES] = user_input
-            await self.async_set_unique_id(user_input.get(CONF_USERNAME))
-            self._abort_if_unique_id_configured(
-                {CONF_USERNAME: user_input.get(CONF_USERNAME)}
-            )
-
             if self.source == SOURCE_REAUTH:
                 return self.async_update_reload_and_abort(
                     self._get_reauth_entry(),
@@ -192,6 +185,9 @@ class BoschHomecomConfigFlow(ConfigFlow, domain=DOMAIN):
                     self._get_reconfigure_entry(),
                     data_updates=self.data,
                 )
+            username = self.data.get(CONF_USERNAME)
+            await self.async_set_unique_id(username)
+            self._abort_if_unique_id_configured({CONF_USERNAME: username})
             # User is done, create the config entry.
             return self.async_create_entry(title="Bosch HomeCom", data=self.data)
 

--- a/custom_components/bosch_homecom/coordinator.py
+++ b/custom_components/bosch_homecom/coordinator.py
@@ -1,6 +1,9 @@
 """HomeCom coordinator."""
 
+from abc import abstractmethod
+import hashlib
 import logging
+from typing import Any, Generic, TypeVar
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_TOKEN
@@ -27,16 +30,40 @@ from .const import CONF_REFRESH, DEFAULT_UPDATE_INTERVAL, DOMAIN, MANUFACTURER
 
 _LOGGER = logging.getLogger(__name__)
 
+BoschDeviceT = TypeVar(
+    "BoschDeviceT",
+    BHCDeviceGeneric,
+    BHCDeviceRac,
+    BHCDeviceK40,
+    BHCDeviceWddw2,
+    BHCDeviceCommodule,
+)
 
-class BoschComModuleCoordinatorGeneric(DataUpdateCoordinator[BHCDeviceGeneric]):
-    """A coordinator to manage the fetching of BoschCom data."""
+
+def _fingerprint_secret(secret: Any) -> str:
+    """Return a short, non-reversible fingerprint for debug logging."""
+    if not secret:
+        return "missing"
+    if isinstance(secret, bytes):
+        raw = secret
+    elif isinstance(secret, str):
+        raw = secret.encode()
+    else:
+        return f"non_str:{type(secret).__name__}"
+    return hashlib.sha256(raw).hexdigest()[:8]
+
+
+class BoschComModuleCoordinatorBase(
+    DataUpdateCoordinator[BoschDeviceT], Generic[BoschDeviceT]
+):
+    """Base coordinator with shared Bosch auth and device metadata logic."""
 
     def __init__(
         self,
         hass: HomeAssistant,
-        bhc: HomeComRac,
-        device: list,
-        firmware: dict,
+        bhc: Any,
+        device: dict[str, Any],
+        firmware: dict[str, Any],
         entry: ConfigEntry,
         auth_provider: bool,
     ) -> None:
@@ -62,41 +89,108 @@ class BoschComModuleCoordinatorGeneric(DataUpdateCoordinator[BHCDeviceGeneric]):
             manufacturer=MANUFACTURER,
         )
 
-    async def _async_update_data(self) -> BHCDeviceGeneric:
-        """Update data via library."""
+    def _auth_debug_context(self) -> dict[str, Any]:
+        """Return safe auth context for debug logging."""
+        return {
+            "entry_id": self.entry.entry_id,
+            "device_id": self.unique_id,
+            "auth_provider": self.auth_provider,
+            "token": _fingerprint_secret(self.bhc.token),
+            "refresh": _fingerprint_secret(self.bhc.refresh_token),
+        }
+
+    async def _async_refresh_auth(self) -> None:
+        """Refresh Bosch auth state and persist new tokens when they rotate."""
+        try:
+            old_token = self.bhc.token
+            old_refresh_token = self.bhc.refresh_token
+            _LOGGER.debug("Refreshing Bosch auth: %s", self._auth_debug_context())
+            await self.bhc.get_token()
+        except AuthFailedError as err:
+            _LOGGER.warning(
+                "Bosch auth refresh failed: %s error=%s",
+                self._auth_debug_context(),
+                err,
+            )
+            self.entry.async_start_reauth(self.hass)
+            raise UpdateFailed("Bosch authentication expired") from err
+
+        token_changed = old_token != self.bhc.token
+        refresh_changed = old_refresh_token != self.bhc.refresh_token
+        _LOGGER.debug(
+            "Bosch auth refresh completed for %s token_changed=%s refresh_changed=%s new_token=%s new_refresh=%s",
+            self.unique_id,
+            token_changed,
+            refresh_changed,
+            _fingerprint_secret(self.bhc.token),
+            _fingerprint_secret(self.bhc.refresh_token),
+        )
+
+        stored_token = self.entry.data.get(CONF_TOKEN)
+        stored_refresh = self.entry.data.get(CONF_REFRESH)
+        if (
+            not (token_changed or refresh_changed)
+            and stored_token == self.bhc.token
+            and stored_refresh == self.bhc.refresh_token
+        ):
+            return
+
+        new_data = dict(self.entry.data)
+        new_data[CONF_TOKEN] = self.bhc.token
+        new_data[CONF_REFRESH] = self.bhc.refresh_token
+        self.hass.config_entries.async_update_entry(self.entry, data=new_data)
+        _LOGGER.debug(
+            "Device_Id: %s, persisted refreshed Bosch auth tokens",
+            self.unique_id,
+        )
+
+    async def _async_update_data(self) -> BoschDeviceT:
+        """Update data via the underlying Bosch client."""
         if self.auth_provider:
-            try:
-                old_refresh_token = self.bhc.refresh_token
-                await self.bhc.get_token()
-                new_refresh_token = self.bhc.refresh_token
-                new_refresh_token = self.bhc.refresh_token
-                _LOGGER.debug(
-                    "Device_Id: %s, old_refresh_token: %s, new_refresh_token: %s",
-                    self.unique_id,
-                    old_refresh_token,
-                    new_refresh_token,
-                )
-                if old_refresh_token != new_refresh_token:
-                    new_data = dict(self.entry.data)
-                    new_data[CONF_TOKEN] = self.bhc.token
-                    new_data[CONF_REFRESH] = new_refresh_token
-                    self.hass.config_entries.async_update_entry(
-                        self.entry, data=new_data
-                    )
-                    _LOGGER.debug(
-                        "Device_Id: %s, config_token: %s, config_refresh_token: %s",
-                        self.unique_id,
-                        self.entry.data.get(CONF_TOKEN),
-                        self.entry.data.get(CONF_REFRESH),
-                    )
-            except AuthFailedError:
-                self.entry.async_start_reauth(self.hass)
+            await self._async_refresh_auth()
 
         try:
-            data: BHCDeviceGeneric = await self.bhc.async_update(self.unique_id)
+            data = await self.bhc.async_update(self.unique_id)
+        except AuthFailedError as error:
+            _LOGGER.warning(
+                "Bosch async_update auth failure after refresh path: %s error=%s",
+                self._auth_debug_context(),
+                error,
+            )
+            self.entry.async_start_reauth(self.hass)
+            raise UpdateFailed("Bosch authentication expired during update") from error
         except (ApiError, InvalidSensorDataError, RetryError) as error:
             raise UpdateFailed(error) from error
 
+        return self._build_device_data(data)
+
+    @abstractmethod
+    def _build_device_data(self, data: BoschDeviceT) -> BoschDeviceT:
+        """Normalize device data for Home Assistant entities."""
+
+
+BoschCoordinator = BoschComModuleCoordinatorBase[Any]
+
+
+class BoschComModuleCoordinatorGeneric(
+    BoschComModuleCoordinatorBase[BHCDeviceGeneric]
+):
+    """A coordinator to manage the fetching of BoschCom data."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        bhc: HomeComRac,
+        device: dict[str, Any],
+        firmware: dict[str, Any],
+        entry: ConfigEntry,
+        auth_provider: bool,
+    ) -> None:
+        """Initialize coordinator."""
+        super().__init__(hass, bhc, device, firmware, entry, auth_provider)
+
+    def _build_device_data(self, data: BHCDeviceGeneric) -> BHCDeviceGeneric:
+        """Normalize generic device data."""
         return BHCDeviceGeneric(
             device=self.device,
             firmware={},
@@ -104,75 +198,23 @@ class BoschComModuleCoordinatorGeneric(DataUpdateCoordinator[BHCDeviceGeneric]):
         )
 
 
-class BoschComModuleCoordinatorRac(DataUpdateCoordinator[BHCDeviceRac]):
+class BoschComModuleCoordinatorRac(BoschComModuleCoordinatorBase[BHCDeviceRac]):
     """A coordinator to manage the fetching of BoschCom data."""
 
     def __init__(
         self,
         hass: HomeAssistant,
         bhc: HomeComRac,
-        device: list,
-        firmware: dict,
+        device: dict[str, Any],
+        firmware: dict[str, Any],
         entry: ConfigEntry,
         auth_provider: bool,
     ) -> None:
         """Initialize coordinator."""
-        super().__init__(
-            hass,
-            logger=_LOGGER,
-            name=DOMAIN,
-            update_interval=DEFAULT_UPDATE_INTERVAL,
-            always_update=True,
-        )
-        self.bhc = bhc
-        self.unique_id = device["deviceId"]
-        self.device = device
-        self.entry = entry
-        self.auth_provider = auth_provider
+        super().__init__(hass, bhc, device, firmware, entry, auth_provider)
 
-        self.device_info = DeviceInfo(
-            serial_number=self.unique_id,
-            identifiers={(DOMAIN, self.unique_id)},
-            name="Boschcom_" + device["deviceType"] + "_" + device["deviceId"],
-            sw_version=firmware["value"],
-            manufacturer=MANUFACTURER,
-        )
-
-    async def _async_update_data(self) -> BHCDeviceRac:
-        """Update data via library."""
-        if self.auth_provider:
-            try:
-                old_refresh_token = self.bhc.refresh_token
-                await self.bhc.get_token()
-                new_refresh_token = self.bhc.refresh_token
-                new_refresh_token = self.bhc.refresh_token
-                _LOGGER.debug(
-                    "Device_Id: %s, old_refresh_token: %s, new_refresh_token: %s",
-                    self.unique_id,
-                    old_refresh_token,
-                    new_refresh_token,
-                )
-                if old_refresh_token != new_refresh_token:
-                    new_data = dict(self.entry.data)
-                    new_data[CONF_TOKEN] = self.bhc.token
-                    new_data[CONF_REFRESH] = new_refresh_token
-                    self.hass.config_entries.async_update_entry(
-                        self.entry, data=new_data
-                    )
-                    _LOGGER.debug(
-                        "Device_Id: %s, config_token: %s, config_refresh_token: %s",
-                        self.unique_id,
-                        self.entry.data.get(CONF_TOKEN),
-                        self.entry.data.get(CONF_REFRESH),
-                    )
-            except AuthFailedError:
-                self.entry.async_start_reauth(self.hass)
-
-        try:
-            data: BHCDeviceRac = await self.bhc.async_update(self.unique_id)
-        except (ApiError, InvalidSensorDataError, RetryError) as error:
-            raise UpdateFailed(error) from error
-
+    def _build_device_data(self, data: BHCDeviceRac) -> BHCDeviceRac:
+        """Normalize RAC device data."""
         return BHCDeviceRac(
             device=self.device,
             firmware={},
@@ -183,75 +225,23 @@ class BoschComModuleCoordinatorRac(DataUpdateCoordinator[BHCDeviceRac]):
         )
 
 
-class BoschComModuleCoordinatorK40(DataUpdateCoordinator[BHCDeviceK40]):
+class BoschComModuleCoordinatorK40(BoschComModuleCoordinatorBase[BHCDeviceK40]):
     """A coordinator to manage the fetching of BoschCom data."""
 
     def __init__(
         self,
         hass: HomeAssistant,
         bhc: HomeComK40,
-        device: list,
-        firmware: dict,
+        device: dict[str, Any],
+        firmware: dict[str, Any],
         entry: ConfigEntry,
         auth_provider: bool,
     ) -> None:
         """Initialize coordinator."""
-        super().__init__(
-            hass,
-            logger=_LOGGER,
-            name=DOMAIN,
-            update_interval=DEFAULT_UPDATE_INTERVAL,
-            always_update=True,
-        )
-        self.bhc = bhc
-        self.unique_id = device["deviceId"]
-        self.device = device
-        self.entry = entry
-        self.auth_provider = auth_provider
+        super().__init__(hass, bhc, device, firmware, entry, auth_provider)
 
-        self.device_info = DeviceInfo(
-            serial_number=self.unique_id,
-            identifiers={(DOMAIN, self.unique_id)},
-            name="Boschcom_" + device["deviceType"] + "_" + device["deviceId"],
-            sw_version=firmware["value"],
-            manufacturer=MANUFACTURER,
-        )
-
-    async def _async_update_data(self) -> BHCDeviceK40:
-        """Update data via library."""
-        if self.auth_provider:
-            try:
-                old_refresh_token = self.bhc.refresh_token
-                await self.bhc.get_token()
-                new_refresh_token = self.bhc.refresh_token
-                new_refresh_token = self.bhc.refresh_token
-                _LOGGER.debug(
-                    "Device_Id: %s, old_refresh_token: %s, new_refresh_token: %s",
-                    self.unique_id,
-                    old_refresh_token,
-                    new_refresh_token,
-                )
-                if old_refresh_token != new_refresh_token:
-                    new_data = dict(self.entry.data)
-                    new_data[CONF_TOKEN] = self.bhc.token
-                    new_data[CONF_REFRESH] = new_refresh_token
-                    self.hass.config_entries.async_update_entry(
-                        self.entry, data=new_data
-                    )
-                    _LOGGER.debug(
-                        "Device_Id: %s, config_token: %s, config_refresh_token: %s",
-                        self.unique_id,
-                        self.entry.data.get(CONF_TOKEN),
-                        self.entry.data.get(CONF_REFRESH),
-                    )
-            except AuthFailedError:
-                self.entry.async_start_reauth(self.hass)
-
-        try:
-            data: BHCDeviceK40 = await self.bhc.async_update(self.unique_id)
-        except (ApiError, InvalidSensorDataError, RetryError) as error:
-            raise UpdateFailed(error) from error
-
+    def _build_device_data(self, data: BHCDeviceK40) -> BHCDeviceK40:
+        """Normalize K40 device data."""
         return BHCDeviceK40(
             device=self.device,
             firmware=data.firmware,
@@ -273,75 +263,25 @@ class BoschComModuleCoordinatorK40(DataUpdateCoordinator[BHCDeviceK40]):
         )
 
 
-class BoschComModuleCoordinatorWddw2(DataUpdateCoordinator[BHCDeviceWddw2]):
+class BoschComModuleCoordinatorWddw2(
+    BoschComModuleCoordinatorBase[BHCDeviceWddw2]
+):
     """A coordinator to manage the fetching of BoschCom data."""
 
     def __init__(
         self,
         hass: HomeAssistant,
         bhc: HomeComWddw2,
-        device: list,
-        firmware: dict,
+        device: dict[str, Any],
+        firmware: dict[str, Any],
         entry: ConfigEntry,
         auth_provider: bool,
     ) -> None:
         """Initialize coordinator."""
-        super().__init__(
-            hass,
-            logger=_LOGGER,
-            name=DOMAIN,
-            update_interval=DEFAULT_UPDATE_INTERVAL,
-            always_update=True,
-        )
-        self.bhc = bhc
-        self.unique_id = device["deviceId"]
-        self.device = device
-        self.entry = entry
-        self.auth_provider = auth_provider
+        super().__init__(hass, bhc, device, firmware, entry, auth_provider)
 
-        self.device_info = DeviceInfo(
-            serial_number=self.unique_id,
-            identifiers={(DOMAIN, self.unique_id)},
-            name="Boschcom_" + device["deviceType"] + "_" + device["deviceId"],
-            sw_version=firmware["value"],
-            manufacturer=MANUFACTURER,
-        )
-
-    async def _async_update_data(self) -> BHCDeviceWddw2:
-        """Update data via library."""
-        if self.auth_provider:
-            try:
-                old_refresh_token = self.bhc.refresh_token
-                await self.bhc.get_token()
-                new_refresh_token = self.bhc.refresh_token
-                new_refresh_token = self.bhc.refresh_token
-                _LOGGER.debug(
-                    "Device_Id: %s, old_refresh_token: %s, new_refresh_token: %s",
-                    self.unique_id,
-                    old_refresh_token,
-                    new_refresh_token,
-                )
-                if old_refresh_token != new_refresh_token:
-                    new_data = dict(self.entry.data)
-                    new_data[CONF_TOKEN] = self.bhc.token
-                    new_data[CONF_REFRESH] = new_refresh_token
-                    self.hass.config_entries.async_update_entry(
-                        self.entry, data=new_data
-                    )
-                    _LOGGER.debug(
-                        "Device_Id: %s, config_token: %s, config_refresh_token: %s",
-                        self.unique_id,
-                        self.entry.data.get(CONF_TOKEN),
-                        self.entry.data.get(CONF_REFRESH),
-                    )
-            except AuthFailedError:
-                self.entry.async_start_reauth(self.hass)
-
-        try:
-            data: BHCDeviceWddw2 = await self.bhc.async_update(self.unique_id)
-        except (ApiError, InvalidSensorDataError, RetryError) as error:
-            raise UpdateFailed(error) from error
-
+    def _build_device_data(self, data: BHCDeviceWddw2) -> BHCDeviceWddw2:
+        """Normalize WDDW2 device data."""
         return BHCDeviceWddw2(
             device=self.device,
             firmware=data.firmware,
@@ -350,75 +290,25 @@ class BoschComModuleCoordinatorWddw2(DataUpdateCoordinator[BHCDeviceWddw2]):
         )
 
 
-class BoschComModuleCoordinatorCommodule(DataUpdateCoordinator[BHCDeviceCommodule]):
+class BoschComModuleCoordinatorCommodule(
+    BoschComModuleCoordinatorBase[BHCDeviceCommodule]
+):
     """A coordinator to manage the fetching of BoschCom data."""
 
     def __init__(
         self,
         hass: HomeAssistant,
         bhc: HomeComCommodule,
-        device: list,
-        firmware: dict,
+        device: dict[str, Any],
+        firmware: dict[str, Any],
         entry: ConfigEntry,
         auth_provider: bool,
     ) -> None:
         """Initialize coordinator."""
-        super().__init__(
-            hass,
-            logger=_LOGGER,
-            name=DOMAIN,
-            update_interval=DEFAULT_UPDATE_INTERVAL,
-            always_update=True,
-        )
-        self.bhc = bhc
-        self.unique_id = device["deviceId"]
-        self.device = device
-        self.entry = entry
-        self.auth_provider = auth_provider
+        super().__init__(hass, bhc, device, firmware, entry, auth_provider)
 
-        self.device_info = DeviceInfo(
-            serial_number=self.unique_id,
-            identifiers={(DOMAIN, self.unique_id)},
-            name="Boschcom_" + device["deviceType"] + "_" + device["deviceId"],
-            sw_version=firmware["value"],
-            manufacturer=MANUFACTURER,
-        )
-
-    async def _async_update_data(self) -> BHCDeviceCommodule:
-        """Update data via library."""
-        if self.auth_provider:
-            try:
-                old_refresh_token = self.bhc.refresh_token
-                await self.bhc.get_token()
-                new_refresh_token = self.bhc.refresh_token
-                new_refresh_token = self.bhc.refresh_token
-                _LOGGER.debug(
-                    "Device_Id: %s, old_refresh_token: %s, new_refresh_token: %s",
-                    self.unique_id,
-                    old_refresh_token,
-                    new_refresh_token,
-                )
-                if old_refresh_token != new_refresh_token:
-                    new_data = dict(self.entry.data)
-                    new_data[CONF_TOKEN] = self.bhc.token
-                    new_data[CONF_REFRESH] = new_refresh_token
-                    self.hass.config_entries.async_update_entry(
-                        self.entry, data=new_data
-                    )
-                    _LOGGER.debug(
-                        "Device_Id: %s, config_token: %s, config_refresh_token: %s",
-                        self.unique_id,
-                        self.entry.data.get(CONF_TOKEN),
-                        self.entry.data.get(CONF_REFRESH),
-                    )
-            except AuthFailedError:
-                self.entry.async_start_reauth(self.hass)
-
-        try:
-            data: BHCDeviceCommodule = await self.bhc.async_update(self.unique_id)
-        except (ApiError, InvalidSensorDataError, RetryError) as error:
-            raise UpdateFailed(error) from error
-
+    def _build_device_data(self, data: BHCDeviceCommodule) -> BHCDeviceCommodule:
+        """Normalize commodule device data."""
         return BHCDeviceCommodule(
             device=self.device,
             firmware=data.firmware,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,139 @@
+"""Tests for Bosch auth-persisting client wrappers."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.const import CONF_CODE, CONF_TOKEN, CONF_USERNAME
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bosch_homecom.client import PersistentHomeComRac
+from custom_components.bosch_homecom.const import CONF_DEVICES, CONF_REFRESH, DOMAIN
+from homecom_alt import AuthFailedError
+from homecom_alt import ConnectionOptions
+
+
+@pytest.fixture
+def entry():
+    """Return a config entry with stored Bosch auth."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="test-user",
+        unique_id="test-user",
+        data={
+            "123_rac": True,
+            CONF_DEVICES: {"123_rac": True},
+            CONF_REFRESH: "stored_refresh",
+            CONF_TOKEN: "stored_token",
+            CONF_USERNAME: "test-user",
+            CONF_CODE: "valid_code",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_persistent_client_get_token_saves_rotated_auth(hass, entry):
+    """Persist auth immediately when a client call rotates credentials."""
+    entry.add_to_hass(hass)
+    client = PersistentHomeComRac(
+        AsyncMock(),
+        ConnectionOptions(
+            token="stored_token",
+            refresh_token="stored_refresh",
+            brand="bosch",
+        ),
+        "123",
+        True,
+        hass,
+        entry,
+    )
+
+    async def mutate_tokens():
+        client.token = "new_token"
+        client.refresh_token = "new_refresh"
+        return True
+
+    with patch(
+        "custom_components.bosch_homecom.client.HomeComAlt.get_token",
+        new=AsyncMock(side_effect=mutate_tokens),
+    ):
+        await client.get_token()
+
+    assert entry.data[CONF_TOKEN] == "new_token"
+    assert entry.data[CONF_REFRESH] == "new_refresh"
+
+
+@pytest.mark.asyncio
+async def test_persistent_client_get_token_saves_preexisting_runtime_auth(hass, entry):
+    """Persist auth even if runtime state already drifted before the current call."""
+    entry.add_to_hass(hass)
+    client = PersistentHomeComRac(
+        AsyncMock(),
+        ConnectionOptions(
+            token="runtime_token",
+            refresh_token="runtime_refresh",
+            brand="bosch",
+        ),
+        "123",
+        True,
+        hass,
+        entry,
+    )
+
+    with patch(
+        "custom_components.bosch_homecom.client.HomeComAlt.get_token",
+        new=AsyncMock(return_value=None),
+    ):
+        await client.get_token()
+
+    assert entry.data[CONF_TOKEN] == "runtime_token"
+    assert entry.data[CONF_REFRESH] == "runtime_refresh"
+
+
+@pytest.mark.asyncio
+async def test_persistent_clients_serialize_shared_refresh(hass, entry):
+    """Serialize concurrent refresh attempts that share Bosch auth state."""
+    entry.add_to_hass(hass)
+    options = ConnectionOptions(
+        token="stored_token",
+        refresh_token="stored_refresh",
+        brand="bosch",
+    )
+    client_a = PersistentHomeComRac(
+        AsyncMock(),
+        options,
+        "123",
+        True,
+        hass,
+        entry,
+    )
+    client_b = PersistentHomeComRac(
+        AsyncMock(),
+        options,
+        "123",
+        True,
+        hass,
+        entry,
+    )
+
+    async def fake_get_token(_self):
+        seen_refresh = _self.refresh_token
+        await asyncio.sleep(0)
+        if seen_refresh == "stored_refresh":
+            if _self.refresh_token != "stored_refresh":
+                raise AuthFailedError("stale refresh token")
+            _self.token = "new_token"
+            _self.refresh_token = "new_refresh"
+            return True
+        if seen_refresh == "new_refresh":
+            return None
+        raise AssertionError(f"Unexpected refresh state: {seen_refresh}")
+
+    with patch(
+        "custom_components.bosch_homecom.client.HomeComAlt.get_token",
+        new=fake_get_token,
+    ):
+        await asyncio.gather(client_a.get_token(), client_b.get_token())
+
+    assert entry.data[CONF_TOKEN] == "new_token"
+    assert entry.data[CONF_REFRESH] == "new_refresh"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 from homeassistant import config_entries, setup
 from homeassistant.const import CONF_CODE, CONF_TOKEN, CONF_USERNAME
+from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.data_entry_flow import FlowResultType
 from homecom_alt import ApiError, AuthFailedError
 import pytest
@@ -160,6 +161,31 @@ async def test_async_step_browser_invalid(hass, side_effect):
 
 
 @pytest.mark.asyncio
+async def test_async_step_browser_create_failure_returns_form(hass):
+    """Test browser auth failure during HomeComAlt.create."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    flow = hass.config_entries.flow._progress[result["flow_id"]]
+
+    with patch(
+        "custom_components.bosch_homecom.config_flow.async_get_clientsession",
+        return_value=AsyncMock(),
+    ), patch(
+        "custom_components.bosch_homecom.config_flow.HomeComAlt.create",
+        new_callable=AsyncMock,
+        side_effect=AuthFailedError("boom"),
+    ):
+        await flow.async_step_user(user_input={CONF_USERNAME: "test-user"})
+        result = await flow.async_step_browser(user_input={CONF_CODE: "invalid_code"})
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "browser"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+@pytest.mark.asyncio
 async def test_async_step_devices_success(hass):
     """Test the browser step with valid credentials."""
     await setup.async_setup_component(hass, "persistent_notification", {})
@@ -224,6 +250,44 @@ async def test_async_step_devices_success(hass):
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Bosch HomeCom"
+
+
+@pytest.mark.asyncio
+async def test_async_step_devices_aborts_for_duplicate_username(hass):
+    """Test device selection aborts when username is already configured."""
+    existing_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test-user",
+        unique_id="test-user",
+        data={CONF_USERNAME: "test-user", CONF_DEVICES: {"123_generic": True}},
+    )
+    existing_entry.add_to_hass(hass)
+
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    flow = hass.config_entries.flow._progress[result["flow_id"]]
+
+    with patch(
+        "custom_components.bosch_homecom.config_flow.async_get_clientsession",
+        return_value=AsyncMock(),
+    ), patch(
+        "custom_components.bosch_homecom.config_flow.HomeComAlt.create",
+        new_callable=AsyncMock,
+    ) as mock_create:
+        mock_bhc = AsyncMock()
+        mock_bhc.async_get_devices.return_value = [
+            {"deviceId": "123", "deviceType": "generic"}
+        ]
+        mock_bhc.refresh_token = "mock_refresh"
+        mock_bhc.token = "mock_token"
+        mock_create.return_value = mock_bhc
+
+        await flow.async_step_user(user_input={CONF_USERNAME: "test-user"})
+        await flow.async_step_browser(user_input={CONF_CODE: "valid_code"})
+        with pytest.raises(AbortFlow, match="already_configured"):
+            await flow.async_step_devices(user_input={"123_generic": True})
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -147,12 +147,108 @@ async def test_async_update_data_retry_error(hass, entry, bhc, device, firmware)
 
 @pytest.mark.asyncio
 async def test_async_update_data_auth_failed_error(hass, entry, bhc, device, firmware):
-    """Test data update with AuthFailedError."""
+    """Test refresh auth failure starts reauth and stops the update."""
+    entry.add_to_hass(hass)
+    coordinator = BoschComModuleCoordinatorRac(
+        hass, bhc, device, firmware, entry, True
+    )
+    bhc.token = "mock_token"
+    bhc.refresh_token = "mock_refresh"
+    bhc.get_token = AsyncMock(side_effect=AuthFailedError("error_status"))
+    bhc.async_update = AsyncMock()
+    entry.async_start_reauth = Mock()
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+    entry.async_start_reauth.assert_called_once_with(hass)
+    bhc.async_update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_auth_failed_during_update_starts_reauth(
+    hass, entry, bhc, device, firmware
+):
+    """Test update-time auth failure starts reauth and surfaces UpdateFailed."""
     entry.add_to_hass(hass)
     coordinator = BoschComModuleCoordinatorRac(
         hass, bhc, device, firmware, entry, False
     )
-    bhc.async_update = Mock(side_effect=AuthFailedError("error_status"))
+    bhc.token = "mock_token"
+    bhc.refresh_token = "mock_refresh"
+    bhc.async_update = AsyncMock(side_effect=AuthFailedError("error_status"))
+    entry.async_start_reauth = Mock()
 
-    with pytest.raises(AuthFailedError):
+    with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()
+
+    entry.async_start_reauth.assert_called_once_with(hass)
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_persists_rotated_tokens(
+    hass, entry, bhc, device, firmware
+):
+    """Test auth refresh persists changed access and refresh tokens."""
+    entry.add_to_hass(hass)
+    coordinator = BoschComModuleCoordinatorRac(
+        hass, bhc, device, firmware, entry, True
+    )
+    bhc.token = "mock_token"
+    bhc.refresh_token = "mock_refresh"
+
+    async def mutate_tokens():
+        bhc.token = "new_token"
+        bhc.refresh_token = "new_refresh"
+
+    bhc.get_token = AsyncMock(side_effect=mutate_tokens)
+    bhc.async_update = AsyncMock(
+        return_value=BHCDeviceRac(
+            device=device,
+            firmware=firmware,
+            notifications=[],
+            stardard_functions=[],
+            advanced_functions=[],
+            switch_programs=[],
+        )
+    )
+
+    assert entry.data[CONF_TOKEN] == "mock_token"
+    assert entry.data[CONF_REFRESH] == "mock_refresh"
+
+    await coordinator._async_update_data()
+
+    assert entry.data[CONF_TOKEN] == "new_token"
+    assert entry.data[CONF_REFRESH] == "new_refresh"
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_persists_already_rotated_tokens(
+    hass, entry, bhc, device, firmware
+):
+    """Persist in-memory Bosch auth that already diverged from entry storage."""
+    entry.add_to_hass(hass)
+    coordinator = BoschComModuleCoordinatorRac(
+        hass, bhc, device, firmware, entry, True
+    )
+    bhc.token = "runtime_token"
+    bhc.refresh_token = "runtime_refresh"
+    bhc.get_token = AsyncMock(return_value=None)
+    bhc.async_update = AsyncMock(
+        return_value=BHCDeviceRac(
+            device=device,
+            firmware=firmware,
+            notifications=[],
+            stardard_functions=[],
+            advanced_functions=[],
+            switch_programs=[],
+        )
+    )
+
+    assert entry.data[CONF_TOKEN] == "mock_token"
+    assert entry.data[CONF_REFRESH] == "mock_refresh"
+
+    await coordinator._async_update_data()
+
+    assert entry.data[CONF_TOKEN] == "runtime_token"
+    assert entry.data[CONF_REFRESH] == "runtime_refresh"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,14 +4,15 @@ import json
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.const import CONF_CODE, CONF_TOKEN, CONF_USERNAME
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
-from homecom_alt import BHCDeviceRac
+from homecom_alt import AuthFailedError, BHCDeviceRac
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.bosch_homecom import PLATFORMS
+from custom_components.bosch_homecom import PLATFORMS, async_setup_entry
 from custom_components.bosch_homecom.const import (
     CONF_DEVICES,
     CONF_REFRESH,
@@ -78,10 +79,8 @@ async def test_entry_setup_unload(hass, entry, devices, sensor_data):
     ), patch(
         "custom_components.bosch_homecom.HomeComRac.get_token",
         new_callable=AsyncMock,
-    ), patch(
-        "custom_components.bosch_homecom.HomeComAlt.create", new_callable=AsyncMock
-    ) as mock_create:
-        # Mock the BHC instance returned by HomeComAlt.create
+    ), patch("custom_components.bosch_homecom.HomeComAlt") as mock_create:
+        # Mock the BHC instance returned by HomeComAlt(...)
         mock_bhc = AsyncMock()
         mock_bhc.refresh_token = "mock_refresh"
         mock_bhc.token = "mock_token"
@@ -113,3 +112,16 @@ async def test_entry_setup_unload(hass, entry, devices, sensor_data):
 async def test_async_setup(hass):
     """Test the component gets setup."""
     assert await async_setup_component(hass, DOMAIN, {}) is True
+
+
+@pytest.mark.asyncio
+async def test_entry_setup_auth_failed_during_create(hass, entry):
+    """Test config entry setup fails cleanly when auth bootstrap fails."""
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.bosch_homecom.HomeComAlt",
+        side_effect=AuthFailedError("boom"),
+    ):
+        with pytest.raises(ConfigEntryAuthFailed):
+            await async_setup_entry(hass, entry)


### PR DESCRIPTION
# PR 1: Harden auth refresh and setup bootstrap

## Summary

This PR hardens the Bosch HomeCom authentication lifecycle in three places:

- config flow bootstrap
- runtime token refresh
- client-side credential persistence

The goal is to make the integration recover and stay healthy across normal Home Assistant restarts without forcing repeated Bosch SingleKey reauthentication.

## Why this change was needed

I ran this integration against a live Bosch K40 setup and repeatedly hit a practical failure mode:

- Bosch entities would work after a fresh browser-code reauthentication
- the integration could stay healthy while Home Assistant remained up
- after a restart, the config entry would often fall back to `setup_error: Failed to refresh`
- Bosch entities would then become `unavailable` and a new reauth repair would appear

In short, the integration behaved as if the live session was not being carried safely through restart and refresh boundaries.

On this live system the heat pump is a **Bosch Compress 7001i AW 13 OR-T** with **AWM 17 B** indoor unit, exposed through the K40/HomeCom path.

Test environment:

- Home Assistant Core **2026.3.2**
- `bosch-homecom-hass` **1.3.30**
- `homecom_alt >= 1.5.7`

## What this PR changes

### 1. Guard setup bootstrap auth failures

- Wrap HomeCom client creation inside the existing setup error handling path.
- Turn startup auth failures into clean `ConfigEntryAuthFailed` instead of letting them fail less explicitly.

### 2. Fix config-flow duplicate detection and auth bootstrap edge cases

- Use the stored username when setting the unique ID during device selection.
- Return cleanly from browser auth if Bosch client creation fails, instead of falling through into later device calls.

### 3. Persist rotated credentials immediately

- Introduce persistent Bosch client wrappers that sync updated `token` and `refresh` values back into the config entry as soon as refresh happens.
- Persist runtime auth state even if in-memory Bosch credentials have already drifted from stored entry data.

### 4. Serialize shared refresh attempts

- Add a shared auth lock on the shared Bosch connection options.
- Prevent concurrent refresh attempts from racing on the same refresh token and invalidating each other.

### 5. Fail fast on auth refresh problems

- Stop coordinator updates immediately on `AuthFailedError`
- Start reauth cleanly instead of continuing deeper into update calls with invalid auth

## Real-world effect

On the live K40 installation that motivated this work, this patch set appears to have resolved the practical logout/session issue:

- Bosch was reauthenticated once on the patched build
- Home Assistant restarts no longer immediately forced reauth
- Bosch sensors remained healthy for about two days of runtime and repeated configuration/dashboard work

That is not proof that every Bosch/SingleKey edge case is solved, but it is strong evidence that the restart/session regression observed on this system has been materially improved.

## Tests

Added regression coverage for:

- browser auth failure during Bosch client creation
- duplicate username protection during device selection
- setup auth failure during bootstrap
- auth refresh failure starting reauth and aborting update
- token rotation persistence
- persistence of already-diverged runtime auth
- shared refresh locking behavior

Command used locally:

```bash
pytest -q tests/test_client.py tests/test_config_flow.py tests/test_init.py tests/test_coordinator.py
```

## Scope

This PR is intentionally limited to auth/session hardening.

It does **not** include:

- reauth/reconfigure UX cleanup
- translation updates
- diagnostics cleanup
- sensor/history surface changes

Those are better reviewed separately.
