### PR TITLE
Redact refresh tokens from diagnostics

### DIFF
--- a/custom_components/bosch_homecom/diagnostics.py
+++ b/custom_components/bosch_homecom/diagnostics.py
@@ -9,7 +9,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CODE, CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
-TO_REDACT = {CONF_PASSWORD, CONF_USERNAME, CONF_CODE, CONF_TOKEN}
+from .const import CONF_REFRESH
+
+TO_REDACT = {CONF_PASSWORD, CONF_USERNAME, CONF_CODE, CONF_TOKEN, CONF_REFRESH}
 
 
 async def async_get_config_entry_diagnostics(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,44 @@
+"""Tests for diagnostics."""
+
+from types import SimpleNamespace
+
+from homeassistant.const import CONF_CODE, CONF_TOKEN, CONF_USERNAME
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bosch_homecom.const import CONF_REFRESH, DOMAIN
+from custom_components.bosch_homecom.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+
+
+@pytest.mark.asyncio
+async def test_async_get_config_entry_diagnostics_redacts_refresh_token(hass):
+    """Test diagnostics redact Bosch auth material, including refresh tokens."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test-user",
+        data={
+            CONF_USERNAME: "test-user",
+            CONF_CODE: "valid_code",
+            CONF_TOKEN: "access_token",
+            CONF_REFRESH: "refresh_token",
+        },
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = [
+        SimpleNamespace(
+            data=SimpleNamespace(
+                device={"deviceId": "123"},
+                firmware={"value": "1.0.0"},
+                notifications=[],
+            )
+        )
+    ]
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diagnostics["info"][CONF_USERNAME] == "**REDACTED**"
+    assert diagnostics["info"][CONF_CODE] == "**REDACTED**"
+    assert diagnostics["info"][CONF_TOKEN] == "**REDACTED**"
+    assert diagnostics["info"][CONF_REFRESH] == "**REDACTED**"


### PR DESCRIPTION
# PR 2: Redact refresh tokens from diagnostics

## Summary

This PR extends diagnostics redaction to cover the Bosch refresh token.

## Why this change was needed

The integration already redacted:

- username
- browser auth code
- access token
- password

But it did **not** redact the refresh token.

For this integration, the refresh token is part of the effective authentication material. Exposing it in diagnostics is unnecessary and weakens the safety of support data sharing.

## What this PR changes

- Add `CONF_REFRESH` to the diagnostics redaction set
- Add a regression test to ensure refresh tokens are redacted in diagnostics output

## Tests

```bash
pytest -q tests/test_diagnostics.py
```

Also verified as part of the full local test suite on Home Assistant Core **2026.3.2** against the current custom component codebase.

## Scope

This PR is intentionally small and limited to diagnostics hygiene.
