### PR TITLE
Store coordinators per entry and route services by device ID

### DIFF
--- a/custom_components/bosch_homecom/__init__.py
+++ b/custom_components/bosch_homecom/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import timedelta
+from typing import Any, Iterable
 
 from aiohttp.client_exceptions import ClientConnectorError, ClientError
 from homecom_alt import (
@@ -64,9 +65,30 @@ _LOGGER = logging.getLogger(__name__)
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
+def _get_domain_coordinators(hass: HomeAssistant) -> dict[str, list[Any]]:
+    """Return the per-entry coordinator registry for this integration."""
+    return hass.data.setdefault(DOMAIN, {})
+
+
+def _iter_coordinators(hass: HomeAssistant) -> Iterable[Any]:
+    """Iterate all active Bosch coordinators across every config entry."""
+    for coordinators in _get_domain_coordinators(hass).values():
+        yield from coordinators
+
+
+def _find_coordinator_by_device_id(
+    hass: HomeAssistant, device_id: str
+) -> Any | None:
+    """Find the coordinator that owns a Bosch device ID."""
+    return next(
+        (c for c in _iter_coordinators(hass) if c.device["deviceId"] == device_id),
+        None,
+    )
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up platform from a ConfigEntry."""
-    coordinators: list[any] = []
+    coordinators: list[Any] = []
     token: str | None = entry.data.get(CONF_TOKEN)
     refresh: str | None = entry.data.get(CONF_REFRESH)
 
@@ -216,7 +238,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
     entry.runtime_data = coordinators
-    hass.data[DOMAIN] = {"coordinators": coordinators}
+    _get_domain_coordinators(hass)[entry.entry_id] = coordinators
     # Forward the setup to the sensor platform.
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -249,7 +271,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        _get_domain_coordinators(hass).pop(entry.entry_id, None)
+    return unload_ok
 
 
 async def async_setup(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -259,14 +284,7 @@ async def async_setup(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Service to change temperature."""
         for entity in call.data["entity_id"]:
             device_id = entity.split("_")[2]
-            coordinator = next(
-                (
-                    c
-                    for c in hass.data.get(DOMAIN).get("coordinators")
-                    if c.device["deviceId"] == device_id
-                ),
-                None,
-            )
+            coordinator = _find_coordinator_by_device_id(hass, device_id)
             if not coordinator:
                 _LOGGER.error("Coordinator not found for entity %s", entity)
                 return
@@ -287,14 +305,7 @@ async def async_setup(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Service to control extrahot water service."""
         for entity in call.data["entity_id"]:
             device_id = entity.split("_")[2]
-            coordinator = next(
-                (
-                    c
-                    for c in hass.data.get(DOMAIN).get("coordinators")
-                    if c.device["deviceId"] == device_id
-                ),
-                None,
-            )
+            coordinator = _find_coordinator_by_device_id(hass, device_id)
             if not coordinator:
                 _LOGGER.error("Coordinator not found for entity %s", entity)
                 return
@@ -318,7 +329,14 @@ async def async_setup(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def get_custom_path_service(call: ServiceCall) -> ServiceResponse:
         """Service to query any endpoint."""
-        coordinator = hass.data.get(DOMAIN).get("coordinators")[0]
+        coordinator = _find_coordinator_by_device_id(
+            hass, str(call.data.get("device_id"))
+        )
+        if coordinator is None:
+            _LOGGER.error(
+                "Coordinator not found for device %s", call.data.get("device_id")
+            )
+            return {}
         result = await coordinator.bhc.async_action_universal_get(
             str(call.data.get("device_id")),
             call.data.get("path"),

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from homeassistant.config_entries import ConfigEntryState
 from unittest.mock import AsyncMock, Mock, patch
 
 from homeassistant.const import CONF_CODE, CONF_TOKEN, CONF_USERNAME
@@ -11,7 +12,7 @@ from homecom_alt import BHCDeviceRac
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.bosch_homecom import PLATFORMS
+from custom_components.bosch_homecom import DOMAIN as COMPONENT_DOMAIN, PLATFORMS
 from custom_components.bosch_homecom.const import (
     CONF_DEVICES,
     CONF_REFRESH,
@@ -113,3 +114,182 @@ async def test_entry_setup_unload(hass, entry, devices, sensor_data):
 async def test_async_setup(hass):
     """Test the component gets setup."""
     assert await async_setup_component(hass, DOMAIN, {}) is True
+
+
+@pytest.mark.asyncio
+async def test_entry_setup_stores_coordinators_per_entry(hass, sensor_data):
+    """Test coordinator storage does not overwrite previous config entries."""
+    entry_one = MockConfigEntry(
+        domain=DOMAIN,
+        title="test-user-1",
+        unique_id="test-user-1",
+        data={
+            "123_rac": True,
+            CONF_DEVICES: {"123_rac": True},
+            CONF_REFRESH: "mock_refresh_1",
+            CONF_TOKEN: "mock_token_1",
+            CONF_USERNAME: "test-user-1",
+            CONF_CODE: "valid_code_1",
+        },
+    )
+    entry_two = MockConfigEntry(
+        domain=DOMAIN,
+        title="test-user-2",
+        unique_id="test-user-2",
+        data={
+            "456_rac": True,
+            CONF_DEVICES: {"456_rac": True},
+            CONF_REFRESH: "mock_refresh_2",
+            CONF_TOKEN: "mock_token_2",
+            CONF_USERNAME: "test-user-2",
+            CONF_CODE: "valid_code_2",
+        },
+    )
+    entry_one.add_to_hass(hass)
+    entry_two.add_to_hass(hass)
+
+    def create_side_effect(*args, **kwargs):
+        token = kwargs["options"].token if "options" in kwargs else args[1].token
+        mock_bhc = AsyncMock()
+        if token == "mock_token_1":
+            mock_bhc.refresh_token = "mock_refresh_1"
+            mock_bhc.token = "mock_token_1"
+            mock_bhc.async_get_devices.return_value = [{"deviceId": "123", "deviceType": "rac"}]
+            mock_bhc.async_get_firmware.return_value = {"value": "1.0.0"}
+        else:
+            mock_bhc.refresh_token = "mock_refresh_2"
+            mock_bhc.token = "mock_token_2"
+            mock_bhc.async_get_devices.return_value = [{"deviceId": "456", "deviceType": "rac"}]
+            mock_bhc.async_get_firmware.return_value = {"value": "2.0.0"}
+        return mock_bhc
+
+    def rac_side_effect(*args, **kwargs):
+        device_id = args[2]
+        client = AsyncMock()
+        client.get_token = AsyncMock()
+        client.async_update = AsyncMock(
+            return_value=BHCDeviceRac(
+                device={"deviceId": device_id, "deviceType": "rac"},
+                firmware=sensor_data["firmwares"],
+                notifications=sensor_data["notifications"],
+                stardard_functions=sensor_data["stardard_functions"],
+                advanced_functions=sensor_data["advanced_functions"],
+                switch_programs=sensor_data["switch_programs"],
+            )
+        )
+        client.async_action_universal_get = AsyncMock(return_value={"device_id": device_id})
+        return client
+
+    with patch(
+        "custom_components.bosch_homecom.HomeComAlt.create",
+        side_effect=create_side_effect,
+    ), patch(
+        "custom_components.bosch_homecom.HomeComRac",
+        side_effect=rac_side_effect,
+    ):
+        assert await hass.config_entries.async_setup(entry_one.entry_id) is True
+        if entry_two.state is ConfigEntryState.NOT_LOADED:
+            assert await hass.config_entries.async_setup(entry_two.entry_id) is True
+        await hass.async_block_till_done()
+
+    domain_data = hass.data[COMPONENT_DOMAIN]
+    assert set(domain_data) == {entry_one.entry_id, entry_two.entry_id}
+    assert domain_data[entry_one.entry_id][0].device["deviceId"] == "123"
+    assert domain_data[entry_two.entry_id][0].device["deviceId"] == "456"
+
+
+@pytest.mark.asyncio
+async def test_get_custom_path_service_uses_matching_entry_coordinator(hass, sensor_data):
+    """Test custom path service resolves the correct coordinator across entries."""
+    await async_setup_component(hass, DOMAIN, {})
+
+    entry_one = MockConfigEntry(
+        domain=DOMAIN,
+        title="test-user-1",
+        unique_id="test-user-1",
+        data={
+            "123_rac": True,
+            CONF_DEVICES: {"123_rac": True},
+            CONF_REFRESH: "mock_refresh_1",
+            CONF_TOKEN: "mock_token_1",
+            CONF_USERNAME: "test-user-1",
+            CONF_CODE: "valid_code_1",
+        },
+    )
+    entry_two = MockConfigEntry(
+        domain=DOMAIN,
+        title="test-user-2",
+        unique_id="test-user-2",
+        data={
+            "456_rac": True,
+            CONF_DEVICES: {"456_rac": True},
+            CONF_REFRESH: "mock_refresh_2",
+            CONF_TOKEN: "mock_token_2",
+            CONF_USERNAME: "test-user-2",
+            CONF_CODE: "valid_code_2",
+        },
+    )
+    entry_one.add_to_hass(hass)
+    entry_two.add_to_hass(hass)
+
+    clients_by_device = {}
+
+    def create_side_effect(*args, **kwargs):
+        token = kwargs["options"].token if "options" in kwargs else args[1].token
+        mock_bhc = AsyncMock()
+        if token == "mock_token_1":
+            mock_bhc.refresh_token = "mock_refresh_1"
+            mock_bhc.token = "mock_token_1"
+            mock_bhc.async_get_devices.return_value = [{"deviceId": "123", "deviceType": "rac"}]
+            mock_bhc.async_get_firmware.return_value = {"value": "1.0.0"}
+        else:
+            mock_bhc.refresh_token = "mock_refresh_2"
+            mock_bhc.token = "mock_token_2"
+            mock_bhc.async_get_devices.return_value = [{"deviceId": "456", "deviceType": "rac"}]
+            mock_bhc.async_get_firmware.return_value = {"value": "2.0.0"}
+        return mock_bhc
+
+    def rac_side_effect(*args, **kwargs):
+        device_id = args[2]
+        client = AsyncMock()
+        client.get_token = AsyncMock()
+        client.async_update = AsyncMock(
+            return_value=BHCDeviceRac(
+                device={"deviceId": device_id, "deviceType": "rac"},
+                firmware=sensor_data["firmwares"],
+                notifications=sensor_data["notifications"],
+                stardard_functions=sensor_data["stardard_functions"],
+                advanced_functions=sensor_data["advanced_functions"],
+                switch_programs=sensor_data["switch_programs"],
+            )
+        )
+        client.async_action_universal_get = AsyncMock(return_value={"device_id": device_id})
+        clients_by_device[device_id] = client
+        return client
+
+    with patch(
+        "custom_components.bosch_homecom.HomeComAlt.create",
+        side_effect=create_side_effect,
+    ), patch(
+        "custom_components.bosch_homecom.HomeComRac",
+        side_effect=rac_side_effect,
+    ):
+        assert await hass.config_entries.async_setup(entry_one.entry_id) is True
+        if entry_two.state is ConfigEntryState.NOT_LOADED:
+            assert await hass.config_entries.async_setup(entry_two.entry_id) is True
+        await hass.async_block_till_done()
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        "get_custom_path_service",
+        {"device_id": "456", "path": "/test/path"},
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response == {"device_id": "456"}
+    clients_by_device["123"].async_action_universal_get.assert_not_called()
+    clients_by_device["456"].async_action_universal_get.assert_awaited_once_with(
+        "456",
+        "/test/path",
+    )


### PR DESCRIPTION
# PR 3: Store coordinators per entry and route services by device ID

## Summary

This PR fixes multi-entry coordinator storage and custom service routing.

## Why this change was needed

The integration currently stores coordinators in one flat `hass.data[DOMAIN]["coordinators"]` list.

That creates two correctness problems:

- loading a later Bosch config entry can overwrite the earlier coordinator registry
- custom services can resolve the wrong coordinator, especially when more than one Bosch config entry is loaded

This is not primarily an auth issue. It is a correctness issue in how integration-global state is stored and resolved.

I did not have a live multi-entry setup on my Home Assistant instance while preparing this change.

The issue is still visible from the integration's coordinator storage and service-resolution code paths: coordinator state is stored globally, and custom services resolve from that shared state.

The added tests cover the multi-entry scenarios this PR is intended to fix.

## What this PR changes

- Store coordinators per config entry instead of one shared flat list
- Add helpers to iterate coordinators across all loaded entries
- Resolve custom services by matching `device_id` to the owning coordinator
- Clean up per-entry coordinator storage on unload

## Real-world effect

This makes the integration safer for:

- multiple loaded Bosch entries
- custom service calls targeting a specific Bosch device
- future maintenance, because coordinator ownership becomes explicit

## Tests

Added regression coverage for:

- per-entry coordinator storage
- custom service lookup using the correct coordinator when multiple entries are loaded

Command used locally:

```bash
pytest -q tests/test_init.py
```

Also verified as part of the full local test suite on Home Assistant Core **2026.3.2** against the current custom component codebase.

## Scope

This PR is intentionally limited to multi-entry storage and service lookup correctness.

It does **not** include:

- auth/session hardening
- config-flow UX changes
- diagnostics cleanup
- sensor/history changes
