### PR TITLE
fix: handle None outdoor_temp in BoschComSensorOutdoorTemp.state

### DIFF
--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -838,12 +838,20 @@ class BoschComSensorOutdoorTemp(BoschComSensorBase):
     def state(self):
         """Return BoschComSensorHc outdoorTemp."""
         outdoor = self.coordinator.data.outdoor_temp
+        if not outdoor:
+            return None
         unit_str = outdoor.get("unitOfMeasure")
         if unit_str == "F":
             self._attr_native_unit_of_measurement = UnitOfTemperature.FAHRENHEIT
         else:
             self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
-        return float(outdoor.get("value", "unknown"))
+        value = outdoor.get("value")
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
 
 
 class BoschComSensorHs(BoschComSensorBase):


### PR DESCRIPTION
## Summary

Defensive `None` handling in `BoschComSensorOutdoorTemp.state` so the entity doesn't crash during creation when the first poll cycle fails.

## Problem

When `coordinator.data.outdoor_temp` is `None` (because the polling cycle failed or the endpoint returned an empty response), the sensor crashes:

```
File "/config/custom_components/bosch_homecom/sensor.py", line 841, in state
    unit_str = outdoor.get("unitOfMeasure")
               ^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```

This blocks entity creation entirely, so `outdoor_temp_sensor` never appears in the device — visible only as 3 of 4 entities in the UI. This is especially likely to happen on iCom devices where the first cycle frequently times out due to gateway-wide rate limiting (see #120).

## Change

```python
@property
def state(self):
    outdoor = self.coordinator.data.outdoor_temp
    if not outdoor:
        return None
    unit_str = outdoor.get("unitOfMeasure")
    ...
    value = outdoor.get("value")
    if value is None:
        return None
    try:
        return float(value)
    except (TypeError, ValueError):
        return None
```

- Early return `None` when `outdoor` is empty
- `float()` is wrapped in a `try` because `outdoor.get("value", "unknown")` previously meant `float("unknown")` would raise `ValueError` if value key existed but was missing/non-numeric

## Impact (expected)

- Entity creates successfully even when first poll fails
- Reports `unavailable` when no data, populates correctly once data arrives
- No behavior change when data is present and valid

## Status

⚠️ **Not yet runtime-tested** — the patch was written from the traceback, but I have not yet installed the fork in HA. Happy to test if you'd like specific verification before merging.

## Reference

Reported in #120. Pairs with serbanb11/homecom_alt#75 (transient-error caching to prevent the underlying rate-limit cascade).