### PR TITLE
Change 'Zeitgesteuert' to 'Auto' in German translation

### DIFF
--- a/custom_components/bosch_homecom/translations/de.json
+++ b/custom_components/bosch_homecom/translations/de.json
@@ -81,7 +81,7 @@
                             "dem": "Bedarfsgeregelt",
                             "powerVent": "Intensivlüftung",
                             "fallAsleep": "Schlafen",
-                            "time": "Zeitgesteuert",
+                            "time": "Auto",
                             "party": "Party",
                             "fireplace": "Kamin"
                         }


### PR DESCRIPTION
The time based schedule is called "Auto" within the app. The subtitle reads "Folgt dem von Ihnen festgelegten Zeitprogramm". I think the translation should follow the app as closely as possible.