### PR TITLE
fix: resolve unit of measurement from API node for all generic sensors

### DIFF
--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -1205,6 +1205,27 @@ class DynamicPathResolver:
         return cur
 
 
+_UNIT_NORMALISE: dict[str, str] = {
+    # Volume flow
+    "l/min": "L/min",
+    "l/h":   "L/h",
+    # Volume
+    "l":     "L",
+    # Energy
+    "kwh":   "kWh",
+    "wh":    "Wh",
+    # Power
+    "w":     "W",
+    "kw":    "kW",
+    # Pressure
+    "bar":   "bar",
+    # Electrical (EV charger)
+    "v":     "V",
+    "a":     "A",
+    "hz":    "Hz",
+}
+
+
 class BoschComGenericSensor(CoordinatorEntity, SensorEntity):
     """Generic read-only sensor for Bosch HomeCom values."""
 
@@ -1243,15 +1264,16 @@ class BoschComGenericSensor(CoordinatorEntity, SensorEntity):
         """Resolve the live unit from the API's unitOfMeasure node, falling
         back to the descriptor-declared unit when the API doesn't expose one.
         """
-        if self._attr_device_class != SensorDeviceClass.TEMPERATURE:
-            return self._declared_unit
         node = self._resolver.get_node(self._coordinator_data_as_dict())
         if isinstance(node, dict):
             unit_str = node.get("unitOfMeasure")
-            if unit_str == "F":
-                return UnitOfTemperature.FAHRENHEIT
-            if unit_str == "C":
-                return UnitOfTemperature.CELSIUS
+            if unit_str:
+                if self._attr_device_class != SensorDeviceClass.TEMPERATURE:
+                    return _UNIT_NORMALISE.get(unit_str, unit_str)
+                if unit_str == "F":
+                    return UnitOfTemperature.FAHRENHEIT
+                if unit_str == "C":
+                    return UnitOfTemperature.CELSIUS
         return self._declared_unit
 
     @property


### PR DESCRIPTION
BoschComGenericSensor.native_unit_of_measurement previously only read
  unitOfMeasure from the API node for temperature sensors. Non-temperature
  sensors (e.g. water_flow) always returned the descriptor-declared unit,
  which was None, leaving them unitless.
  
  Fix by reading the API node first for all sensor types, then branching
  on device class. Also adds _UNIT_NORMALISE to convert lowercase Bosch
  API unit strings (e.g. "l/min") to their conventional forms ("L/min").

## Problem
`BoschComGenericSensor.native_unit_of_measurement` only read `unitOfMeasure` 
from the API node for temperature sensors. All other sensors (e.g. `water_flow`) 
always returned the descriptor-declared unit, which was `None`, leaving them 
registered as unitless in HA.

## Fix
- Read the API node first for all sensor types, then branch on device class
- Add `_UNIT_NORMALISE` to convert lowercase Bosch API unit strings to their 
  conventional forms (e.g. `"l/min"` → `"L/min"`)

## Tested on
- WDDW2 (Tronic 8500i) — water_flow now correctly shows L/min