### PR TITLE
Flush config entries store after refresh-token rotation (fix recurring re-auth)

### DIFF
--- a/custom_components/bosch_homecom/coordinator.py
+++ b/custom_components/bosch_homecom/coordinator.py
@@ -90,6 +90,16 @@ class BoschComModuleCoordinatorBase(DataUpdateCoordinator[T]):
                     self.hass.config_entries.async_update_entry(
                         self.entry, data=new_data
                     )
+                    # Bosch SingleKey-ID issues single-use refresh tokens, so the
+                    # rotated token MUST be on disk before the next poll. The
+                    # write above is debounced — if HA restarts/crashes inside
+                    # the debounce window, the now-invalid old token is what's
+                    # persisted, and the next start fails with "Failed to refresh"
+                    # and forces a manual browser re-login.
+                    # Force an immediate flush to close that race window.
+                    await self.hass.config_entries._store.async_save(
+                        self.hass.config_entries._data_to_save()
+                    )
                     _LOGGER.debug(
                         "Device_Id: %s, persisted refreshed auth tokens",
                         self.unique_id,


### PR DESCRIPTION
## Problem

Users (myself included) keep losing authorization to the integration — every few days / weeks HA throws "Failed to refresh" for `bosch_homecom` and the only way back in is to manually run the SingleKey-ID browser flow and paste a fresh code.

## Root cause

Bosch SingleKey-ID issues **single-use** refresh tokens. Each call to `bhc.get_token()` rotates the refresh token and immediately invalidates the previous one on the auth server.

In [`coordinator.py`](https://github.com/serbanb11/bosch-homecom-hass/blob/main/custom_components/bosch_homecom/coordinator.py#L90-L96), after a rotation the new pair is written via:

```python
self.hass.config_entries.async_update_entry(self.entry, data=new_data)
```

That write is **debounced** by HA (default ~1s) before it hits `.storage/core.config_entries`. If HA restarts or crashes inside the debounce window — common in real deployments (HA OS updates, host reboots, container restarts, OOMs, supervisor restarts) — the on-disk copy still contains the **previous, now-invalid** refresh token. On the next start the integration immediately fails with "Failed to refresh", and the user is forced into a manual re-auth.

This is a race window, not a logic bug, which is why it looks intermittent and is hard to repro in normal testing — but for users on HA OS with auto-updates, or unstable hosts, it triggers frequently.

## Proposed fix

Force-flush the config-entries store right after `async_update_entry`, closing the race window:

```python
self.hass.config_entries.async_update_entry(self.entry, data=new_data)
await self.hass.config_entries._store.async_save(
    self.hass.config_entries._data_to_save()
)
```

After this, the rotated token is on disk before the coordinator returns, so any restart afterwards picks up the valid token.

## Caveat — private API

`_store` and `_data_to_save()` are private on `ConfigEntries`. I couldn't find a public flush helper in current HA core. Open to alternatives if there's a supported way I missed — e.g.

- Calling `async_update_entry` with a kwarg that bypasses debouncing (doesn't seem to exist today),
- Exposing `Store.async_save` via a public method on `ConfigEntries` (would need a HA core PR),
- Writing the tokens to a separate `helpers.storage.Store` we own (sidesteps the issue entirely, but moves auth state out of the ConfigEntry).

Happy to switch approaches based on your preference; the goal is just to make sure a single-use refresh token can't be lost to a debounce race.

## Verification

Reproduces consistently on my install (RAC + commodule device) by killing the HA container right after a coordinator update. With this patch the auth chain survives restarts cleanly across many rotations; without it I'd lose auth every few days.

## Local-patch note

I've been running this 1.3.35 + patch in production for a couple of weeks. Same patch applied cleanly to current `main` (1.3.37).