### PR TITLE
fix(sensor): keep extra_state_attributes as mapping; guard numberOfStarts

### DIFF
--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -600,7 +600,11 @@ class BoschComSensorDhw(BoschComSensorBase):
                     )
 
                 return result
-        return "unknown"
+        # extra_state_attributes must return a mapping. Home Assistant merges
+        # it with `attr |= extra_state_attributes`; returning a string iterates
+        # it as a char sequence and raises
+        # "dictionary update sequence element #0 has length 1; 2 is required".
+        return {}
 
 
 class BoschComSensorHc(BoschComSensorBase):
@@ -833,7 +837,8 @@ class BoschComSensorVentilation(BoschComSensorBase):
                     "demandindoorAirQuality": demandindoorAirQuality_value,
                     "demandrelativeHumidity": demandrelativeHumidity_value,
                 }
-        return "unknown"
+        # See BoschComSensorDhw.extra_state_attributes — must return a mapping.
+        return {}
 
 
 class BoschComSensorOutdoorTemp(BoschComSensorBase):
@@ -950,10 +955,22 @@ class BoschComSensorHs(BoschComSensorBase):
             "values", "unknown"
         )
 
-        numberOfStarts = (self.coordinator.data.heat_sources.get("starts") or {}).get(
-            "values"
-        ) or []
-        numberOfStarts_dict = {k: v for d in numberOfStarts for k, v in d.items()}
+        # The pointt-api occasionally returns 500 for
+        # heatSources/.../numberOfStarts; the upstream lib may then pass a
+        # non-list or a list of non-dict items. Treat anything unexpected as
+        # missing so the entity does not crash during state update.
+        starts_node = self.coordinator.data.heat_sources.get("starts")
+        if not isinstance(starts_node, dict):
+            starts_node = {}
+        numberOfStarts = starts_node.get("values")
+        if not isinstance(numberOfStarts, list):
+            numberOfStarts = []
+        numberOfStarts_dict = {
+            k: v
+            for d in numberOfStarts
+            if isinstance(d, dict)
+            for k, v in d.items()
+        }
 
         returnTemperature = str(
             (self.coordinator.data.heat_sources.get("returnTemperature") or {}).get(


### PR DESCRIPTION
## Summary

Two independent crashes in `sensor.py` that surface together after a pointt-api hiccup:

1. **`BoschComSensorDhw` and `BoschComSensorVentilation` return the string `"unknown"`** from `extra_state_attributes` when no matching entry is found in the coordinator data ([sensor.py:603](https://github.com/serbanb11/bosch-homecom-hass/blob/main/custom_components/bosch_homecom/sensor.py#L603), [sensor.py:840](https://github.com/serbanb11/bosch-homecom-hass/blob/main/custom_components/bosch_homecom/sensor.py#L840)). Home Assistant merges the result into the state-attribute dict via `attr |= extra_state_attributes` — a string operand is iterated as a sequence of single-char items, which raises:

   ```
   ValueError: dictionary update sequence element #0 has length 1; 2 is required
   ```

   The error appears as `Unexpected error updating listener ... for bosch_homecom` and the entity update is aborted. Returning `{}` keeps the contract `Mapping[str, Any]` and lets HA preserve the previous attribute snapshot.

2. **`BoschComSensorHs.extra_state_attributes` parses `heatSources/.../starts/values` as `list[dict]`** ([sensor.py:956](https://github.com/serbanb11/bosch-homecom-hass/blob/main/custom_components/bosch_homecom/sensor.py#L956)). When the pointt-api returns 500 for `heatSources/hs1/numberOfStarts` the library forwards a non-list or a list whose items are not dicts, and the dict-comprehension crashes with `AttributeError`. Guarded with `isinstance` so anything unexpected is treated as missing — downstream `.get("ch", "unknown")` calls still produce `"unknown"` strings on the actual attributes.

Both issues were observed together on a K40 device after a successful coordinator update where the pointt-api had returned 500 for `awayMode/enabled` and `heatSources/hs1/numberOfStarts` earlier in the cycle. The 500-handling itself is in the upstream library and is out of scope here.

## Test plan

- [x] `python3 -m py_compile custom_components/bosch_homecom/sensor.py`
- [x] Applied locally on a Synology-hosted HA instance running a K40 + RAC stack — the `ValueError`/`Unexpected error updating listener` pair that was firing every coordinator cycle is gone.
- [ ] Reviewer: confirm `Mapping[str, Any]` is the documented return type for `extra_state_attributes` (it is in `homeassistant.helpers.entity.Entity`).
- [ ] Reviewer: re-check whether the three other `return "unknown"` branches in `sensor.py` (lines 567, 1053 in `state` / helper context) should stay as strings — they are not `extra_state_attributes` and are not touched here.