### PR TITLE
Fix/missing translations

### DIFF
--- a/custom_components/bosch_homecom/climate.py
+++ b/custom_components/bosch_homecom/climate.py
@@ -27,6 +27,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .const import get_field_number
 from .coordinator import (
     BoschComModuleCoordinatorIcom,
     BoschComModuleCoordinatorK40,
@@ -342,7 +343,7 @@ class BoschComK40Climate(CoordinatorEntity, ClimateEntity):
         """Initialize climate entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "hc"
-        self._attr_translation_placeholders = {"circuit": field}
+        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._attr_should_poll = False
@@ -508,7 +509,7 @@ class BoschComZoneClimate(CoordinatorEntity, ClimateEntity):
         """Initialize zone climate entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "zone"
-        self._attr_translation_placeholders = {"zone": field}
+        self._attr_translation_placeholders = {"zone": get_field_number(field)}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._attr_should_poll = False
@@ -631,7 +632,7 @@ class BoschComRrc2ZoneClimate(CoordinatorEntity, ClimateEntity):
         """Initialize RRC2 zone climate entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "zone"
-        self._attr_translation_placeholders = {"zone": field}
+        self._attr_translation_placeholders = {"zone": get_field_number(field)}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._attr_should_poll = False

--- a/custom_components/bosch_homecom/climate.py
+++ b/custom_components/bosch_homecom/climate.py
@@ -119,7 +119,7 @@ class BoschComRacClimate(CoordinatorEntity, ClimateEntity):
         self._attr_translation_key = "ac"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}"
-        self._attr_name = None
+        self._attr_suggested_object_id = field
         self._attr_should_poll = False
 
         # Call this in __init__ so data is populated right away, since it's

--- a/custom_components/bosch_homecom/climate.py
+++ b/custom_components/bosch_homecom/climate.py
@@ -119,7 +119,7 @@ class BoschComRacClimate(CoordinatorEntity, ClimateEntity):
         self._attr_translation_key = "ac"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}"
-        self._attr_name = field
+        self._attr_name = None
         self._attr_should_poll = False
 
         # Call this in __init__ so data is populated right away, since it's
@@ -346,9 +346,10 @@ class BoschComK40Climate(CoordinatorEntity, ClimateEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field
+        self._attr_name = None
         self._attr_should_poll = False
         self._attr_hvac_mode = HVACMode.OFF
+        self.field = field
 
         # Call this in __init__ so data is populated right away, since it's
         # already available in the coordinator data.
@@ -368,17 +369,17 @@ class BoschComK40Climate(CoordinatorEntity, ClimateEntity):
         if isinstance(self.coordinator, BoschComModuleCoordinatorIcom):
             # icom: use temporaryRoomSetpoint to match the Bosch app behaviour
             await self.coordinator.async_set_temporary_room_setpoint(
-                self._attr_name, temperature
+                self.field, temperature
             )
         elif self._is_cooling():
             # In cooling mode the manualRoomSetpoint endpoint returns 404;
             # the writable setpoint is coolingRoomTempSetpoint instead.
             await self.coordinator.bhc.async_set_hc_cooling_room_temp_setpoint(
-                self.coordinator.unique_id, self._attr_name, temperature
+                self.coordinator.unique_id, self.field, temperature
             )
         else:
             await self.coordinator.bhc.async_set_hc_manual_room_setpoint(
-                self.coordinator.unique_id, self._attr_name, temperature
+                self.coordinator.unique_id, self.field, temperature
             )
 
         # Optimistically reflect the new setpoint immediately — the Bosch cloud
@@ -399,7 +400,7 @@ class BoschComK40Climate(CoordinatorEntity, ClimateEntity):
                 return
 
         await self.coordinator.bhc.async_put_hc_operation_mode(
-            self.coordinator.unique_id, self._attr_name, payload
+            self.coordinator.unique_id, self.field, payload
         )
 
         await self.coordinator.async_request_refresh()
@@ -470,7 +471,7 @@ class BoschComK40Climate(CoordinatorEntity, ClimateEntity):
         also covers cooling season while the compressor is idle.
         """
         for entry in self.coordinator.data.heating_circuits or []:
-            if entry.get("id") == f"/heatingCircuits/{self._attr_name}":
+            if entry.get("id") == f"/heatingCircuits/{self.field}":
                 suwi = (entry.get("currentSuWiMode") or {}).get("value")
                 heatcool = (entry.get("heatCoolMode") or {}).get("value")
                 return suwi == "cooling" or heatcool == "cooling"
@@ -483,7 +484,7 @@ class BoschComK40Climate(CoordinatorEntity, ClimateEntity):
             return
 
         for entry in data.heating_circuits or []:
-            if entry.get("id") == f"/heatingCircuits/{self._attr_name}":
+            if entry.get("id") == f"/heatingCircuits/{self.field}":
                 self._set_heating_circuits(entry)
                 break
 
@@ -509,9 +510,10 @@ class BoschComZoneClimate(CoordinatorEntity, ClimateEntity):
         """Initialize zone climate entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "zone"
+        self._attr_translation_placeholders = {"zone": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field
+        self._attr_name = None
         self._attr_should_poll = False
         self._attr_hvac_mode = HVACMode.HEAT
         self.field = field
@@ -631,9 +633,10 @@ class BoschComRrc2ZoneClimate(CoordinatorEntity, ClimateEntity):
         """Initialize RRC2 zone climate entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "zone"
+        self._attr_translation_placeholders = {"zone": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field
+        self._attr_name = None
         self._attr_should_poll = False
         self._attr_hvac_mode = HVACMode.HEAT
         self.field = field

--- a/custom_components/bosch_homecom/climate.py
+++ b/custom_components/bosch_homecom/climate.py
@@ -324,7 +324,6 @@ class BoschComK40Climate(CoordinatorEntity, ClimateEntity):
     """Representation of a BoschComK40 climate entity."""
 
     _attr_has_entity_name = True
-    _attr_name = None
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_hvac_modes = [
         HVACMode.OFF,
@@ -346,7 +345,6 @@ class BoschComK40Climate(CoordinatorEntity, ClimateEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = None
         self._attr_should_poll = False
         self._attr_hvac_mode = HVACMode.OFF
         self.field = field
@@ -497,7 +495,6 @@ class BoschComZoneClimate(CoordinatorEntity, ClimateEntity):
     """Representation of a BoschCom zone climate entity."""
 
     _attr_has_entity_name = True
-    _attr_name = None
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_hvac_modes = [HVACMode.HEAT, HVACMode.AUTO]
     _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
@@ -513,7 +510,6 @@ class BoschComZoneClimate(CoordinatorEntity, ClimateEntity):
         self._attr_translation_placeholders = {"zone": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = None
         self._attr_should_poll = False
         self._attr_hvac_mode = HVACMode.HEAT
         self.field = field
@@ -636,7 +632,6 @@ class BoschComRrc2ZoneClimate(CoordinatorEntity, ClimateEntity):
         self._attr_translation_placeholders = {"zone": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = None
         self._attr_should_poll = False
         self._attr_hvac_mode = HVACMode.HEAT
         self.field = field

--- a/custom_components/bosch_homecom/climate.py
+++ b/custom_components/bosch_homecom/climate.py
@@ -348,6 +348,7 @@ class BoschComK40Climate(CoordinatorEntity, ClimateEntity):
         self._attr_should_poll = False
         self._attr_hvac_mode = HVACMode.OFF
         self.field = field
+        self._attr_suggested_object_id = field
 
         # Call this in __init__ so data is populated right away, since it's
         # already available in the coordinator data.
@@ -515,6 +516,7 @@ class BoschComZoneClimate(CoordinatorEntity, ClimateEntity):
         self.field = field
         self._manual_temp: float | None = None
         self._clock_temp: float | None = None
+        self._attr_suggested_object_id = field
 
         self.set_attr()
 
@@ -637,6 +639,7 @@ class BoschComRrc2ZoneClimate(CoordinatorEntity, ClimateEntity):
         self.field = field
         self._manual_temp: float | None = None
         self._clock_temp: float | None = None
+        self._attr_suggested_object_id = field
         self.set_attr()
 
     @callback

--- a/custom_components/bosch_homecom/climate.py
+++ b/custom_components/bosch_homecom/climate.py
@@ -27,7 +27,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import get_field_number
 from .coordinator import (
     BoschComModuleCoordinatorIcom,
     BoschComModuleCoordinatorK40,
@@ -343,7 +342,7 @@ class BoschComK40Climate(CoordinatorEntity, ClimateEntity):
         """Initialize climate entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "hc"
-        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
+        self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._attr_should_poll = False
@@ -509,7 +508,7 @@ class BoschComZoneClimate(CoordinatorEntity, ClimateEntity):
         """Initialize zone climate entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "zone"
-        self._attr_translation_placeholders = {"zone": get_field_number(field)}
+        self._attr_translation_placeholders = {"zone": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._attr_should_poll = False
@@ -632,7 +631,7 @@ class BoschComRrc2ZoneClimate(CoordinatorEntity, ClimateEntity):
         """Initialize RRC2 zone climate entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "zone"
-        self._attr_translation_placeholders = {"zone": get_field_number(field)}
+        self._attr_translation_placeholders = {"zone": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._attr_should_poll = False

--- a/custom_components/bosch_homecom/const.py
+++ b/custom_components/bosch_homecom/const.py
@@ -44,33 +44,6 @@ SINGLEKEY_LOGIN_URL = "https://singlekey-id.com/auth/connect/authorize?state=nKq
 
 SINGLEKEY_LOGIN_URL_BUDERUS = "https://singlekey-id.com/auth/connect/authorize?state=nKqS17oMAxqUsQpMznajIr&nonce=5yPvyTqMS3iPb4c8RfGJg1&code_challenge=Fc6eY3uMBJkFqa4VqcULuLuKC5Do70XMw7oa_Pxafw0&redirect_uri=com.buderus.tt.dashtt://app/login&client_id=762162C0-FA2D-4540-AE66-6489F189FADC&response_type=code&prompt=login&scope=openid+email+profile+offline_access+pointt.gateway.claiming+pointt.gateway.removal+pointt.gateway.list+pointt.gateway.users+pointt.gateway.resource.dashapp+pointt.castt.flow.token-exchange+bacon+hcc.tariff.read&code_challenge_method=S256&style_id=tt_bud"
 
-
-def get_field_number(field: str) -> str:
-    """Extract number from field ID for translation placeholders.
-
-    Field IDs use patterns like hc1, zone1, dhw1.
-    This returns just the number (1, 2, 3, etc.) which will be
-    interpolated into translation templates like "Heating circuit {circuit}".
-
-    Examples:
-      hc1 -> 1
-      zone2 -> 2
-      dhw1 -> 1
-    """
-    if field.startswith("zone"):
-        return field[4:]  # "zone1" -> "1"
-    if field.startswith("dhw"):
-        return field[3:]  # "dhw1" -> "1"
-    if field.startswith("hc"):
-        return field[2:]  # "hc1" -> "1"
-    # For any other format, try to extract trailing digits
-    for i in range(len(field) - 1, -1, -1):
-        if field[i].isdigit():
-            continue
-        return field[i + 1:]
-    return field
-
-
 CONF_DEVICES: Final = "devices"
 CONF_REFRESH: Final = "refresh"
 CONF_WB_LABEL: Final = "wb_label"

--- a/custom_components/bosch_homecom/const.py
+++ b/custom_components/bosch_homecom/const.py
@@ -44,6 +44,33 @@ SINGLEKEY_LOGIN_URL = "https://singlekey-id.com/auth/connect/authorize?state=nKq
 
 SINGLEKEY_LOGIN_URL_BUDERUS = "https://singlekey-id.com/auth/connect/authorize?state=nKqS17oMAxqUsQpMznajIr&nonce=5yPvyTqMS3iPb4c8RfGJg1&code_challenge=Fc6eY3uMBJkFqa4VqcULuLuKC5Do70XMw7oa_Pxafw0&redirect_uri=com.buderus.tt.dashtt://app/login&client_id=762162C0-FA2D-4540-AE66-6489F189FADC&response_type=code&prompt=login&scope=openid+email+profile+offline_access+pointt.gateway.claiming+pointt.gateway.removal+pointt.gateway.list+pointt.gateway.users+pointt.gateway.resource.dashapp+pointt.castt.flow.token-exchange+bacon+hcc.tariff.read&code_challenge_method=S256&style_id=tt_bud"
 
+
+def get_field_number(field: str) -> str:
+    """Extract number from field ID for translation placeholders.
+
+    Field IDs use patterns like hc1, zone1, dhw1.
+    This returns just the number (1, 2, 3, etc.) which will be
+    interpolated into translation templates like "Heating circuit {circuit}".
+
+    Examples:
+      hc1 -> 1
+      zone2 -> 2
+      dhw1 -> 1
+    """
+    if field.startswith("zone"):
+        return field[4:]  # "zone1" -> "1"
+    if field.startswith("dhw"):
+        return field[3:]  # "dhw1" -> "1"
+    if field.startswith("hc"):
+        return field[2:]  # "hc1" -> "1"
+    # For any other format, try to extract trailing digits
+    for i in range(len(field) - 1, -1, -1):
+        if field[i].isdigit():
+            continue
+        return field[i + 1:]
+    return field
+
+
 CONF_DEVICES: Final = "devices"
 CONF_REFRESH: Final = "refresh"
 CONF_WB_LABEL: Final = "wb_label"

--- a/custom_components/bosch_homecom/fan.py
+++ b/custom_components/bosch_homecom/fan.py
@@ -53,7 +53,6 @@ class BoschComDhwFan(CoordinatorEntity, FanEntity):
         self._attr_translation_placeholders = {"zone": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-fan"
-        self._attr_name = None
         self._attr_should_poll = False
         self._attr_has_entity_name = True
         self._attr_supported_features = (

--- a/custom_components/bosch_homecom/fan.py
+++ b/custom_components/bosch_homecom/fan.py
@@ -11,7 +11,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.percentage import ordered_list_item_to_percentage
 
-from .const import get_field_number
 from .coordinator import BoschComModuleCoordinatorK40
 
 PARALLEL_UPDATES = 1
@@ -51,7 +50,7 @@ class BoschComDhwFan(CoordinatorEntity, FanEntity):
         super().__init__(coordinator)
         self.field = field
         self._attr_translation_key = "ventilation"
-        self._attr_translation_placeholders = {"zone": get_field_number(field)}
+        self._attr_translation_placeholders = {"zone": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-fan"
         self._attr_should_poll = False

--- a/custom_components/bosch_homecom/fan.py
+++ b/custom_components/bosch_homecom/fan.py
@@ -55,7 +55,7 @@ class BoschComDhwFan(CoordinatorEntity, FanEntity):
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-fan"
         self._attr_should_poll = False
         self._attr_has_entity_name = True
-            self._attr_suggested_object_id = field + "_fan"
+        self._attr_suggested_object_id = field + "_fan"
         self._attr_supported_features = (
             FanEntityFeature.PRESET_MODE
             | FanEntityFeature.TURN_OFF

--- a/custom_components/bosch_homecom/fan.py
+++ b/custom_components/bosch_homecom/fan.py
@@ -55,6 +55,7 @@ class BoschComDhwFan(CoordinatorEntity, FanEntity):
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-fan"
         self._attr_should_poll = False
         self._attr_has_entity_name = True
+            self._attr_suggested_object_id = field + "_fan"
         self._attr_supported_features = (
             FanEntityFeature.PRESET_MODE
             | FanEntityFeature.TURN_OFF

--- a/custom_components/bosch_homecom/fan.py
+++ b/custom_components/bosch_homecom/fan.py
@@ -53,7 +53,7 @@ class BoschComDhwFan(CoordinatorEntity, FanEntity):
         self._attr_translation_placeholders = {"zone": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-fan"
-        self._attr_name = f"{field}_fan"
+        self._attr_name = None
         self._attr_should_poll = False
         self._attr_has_entity_name = True
         self._attr_supported_features = (

--- a/custom_components/bosch_homecom/fan.py
+++ b/custom_components/bosch_homecom/fan.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.percentage import ordered_list_item_to_percentage
 
+from .const import get_field_number
 from .coordinator import BoschComModuleCoordinatorK40
 
 PARALLEL_UPDATES = 1
@@ -50,7 +51,7 @@ class BoschComDhwFan(CoordinatorEntity, FanEntity):
         super().__init__(coordinator)
         self.field = field
         self._attr_translation_key = "ventilation"
-        self._attr_translation_placeholders = {"zone": field}
+        self._attr_translation_placeholders = {"zone": get_field_number(field)}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-fan"
         self._attr_should_poll = False

--- a/custom_components/bosch_homecom/number.py
+++ b/custom_components/bosch_homecom/number.py
@@ -224,7 +224,6 @@ class BoschComNumberVentilationSummerDuration(CoordinatorEntity, NumberEntity):
         self._attr_unique_id = (
             f"{coordinator.unique_id}-{zone_id}-summerbypass-duration"
         )
-        self._attr_name = zone_id + "_summerbypass_duration"
         self._attr_native_min_value = min_value
         self._attr_native_max_value = max_value
         self._coordinator = coordinator

--- a/custom_components/bosch_homecom/number.py
+++ b/custom_components/bosch_homecom/number.py
@@ -225,6 +225,7 @@ class BoschComNumberVentilationSummerDuration(CoordinatorEntity, NumberEntity):
         self._attr_unique_id = (
             f"{coordinator.unique_id}-{zone_id}-summerbypass-duration"
         )
+        self._attr_suggested_object_id = zone_id + "_summerbypass_duration"
         self._attr_native_min_value = min_value
         self._attr_native_max_value = max_value
         self._coordinator = coordinator

--- a/custom_components/bosch_homecom/number.py
+++ b/custom_components/bosch_homecom/number.py
@@ -220,6 +220,7 @@ class BoschComNumberVentilationSummerDuration(CoordinatorEntity, NumberEntity):
         """Initialize number entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "ventilation_summer_duration"
+        self._attr_translation_placeholders = {"zone": zone_id}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = (
             f"{coordinator.unique_id}-{zone_id}-summerbypass-duration"

--- a/custom_components/bosch_homecom/select.py
+++ b/custom_components/bosch_homecom/select.py
@@ -210,7 +210,6 @@ class BoschComSelectAirflowHorizontal(CoordinatorEntity, SelectEntity):
         self._attr_translation_key = "airflow_horizontal"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
 
@@ -283,7 +282,6 @@ class BoschComSelectAirflowVertical(CoordinatorEntity, SelectEntity):
         self._attr_translation_key = "airflow_vertical"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
 
@@ -356,7 +354,6 @@ class BoschComSelectProgram(CoordinatorEntity, SelectEntity):
         self._attr_translation_key = "program"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
 
@@ -451,7 +448,6 @@ class BoschComSelectDhwOperationMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
@@ -518,7 +514,6 @@ class BoschComSelectDhwCurrentTemp(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-temp"
-        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
@@ -585,7 +580,6 @@ class BoschComSelectHcOperationMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
@@ -652,7 +646,6 @@ class BoschComSelectHcSuwiMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-suwi"
-        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
@@ -715,7 +708,6 @@ class BoschComSelectHcHeatcoolMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-heatcool"
-        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
@@ -777,7 +769,6 @@ class BoschComSelectHolidayMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_key = "holiday_mode"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
@@ -821,7 +812,6 @@ class BoschComSelectAwayMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_key = "away_mode"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
@@ -865,7 +855,6 @@ class BoschComSelectHcNightSwitchMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-nightswitch"
-        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
@@ -915,7 +904,6 @@ class BoschComSelectHcControl(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-control"
-        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
@@ -963,7 +951,6 @@ class BoschComSelectVentilationSummerEnable(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"zone": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-summerbypass-enable"
-        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues

--- a/custom_components/bosch_homecom/select.py
+++ b/custom_components/bosch_homecom/select.py
@@ -210,7 +210,7 @@ class BoschComSelectAirflowHorizontal(CoordinatorEntity, SelectEntity):
         self._attr_translation_key = "airflow_horizontal"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field
+        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
 
@@ -283,7 +283,7 @@ class BoschComSelectAirflowVertical(CoordinatorEntity, SelectEntity):
         self._attr_translation_key = "airflow_vertical"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field
+        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
 
@@ -356,7 +356,7 @@ class BoschComSelectProgram(CoordinatorEntity, SelectEntity):
         self._attr_translation_key = "program"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field
+        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
 
@@ -451,15 +451,16 @@ class BoschComSelectDhwOperationMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field
+        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
+        self.field = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
         await self._coordinator.bhc.async_put_dhw_operation_mode(
-            self._coordinator.data.device["deviceId"], self._attr_name, option
+            self._coordinator.data.device["deviceId"], self.field, option
         )
 
         await self._coordinator.async_request_refresh()
@@ -473,11 +474,13 @@ class BoschComSelectDhwOperationMode(CoordinatorEntity, SelectEntity):
             value = data.get(key)
             return value if value is not None else default
 
-        for entry in self.coordinator.data.dhw_circuits:
-            if entry.get("id") == "/dhwCircuits/" + self._attr_name:
-                operationMode = safe_get(entry["operationMode"], "value")
+        operation_mode = None
 
-        return operationMode
+        for entry in self.coordinator.data.dhw_circuits:
+            if entry.get("id") == "/dhwCircuits/" + self.field:
+                operation_mode = safe_get(entry["operationMode"], "value")
+
+        return operation_mode
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -488,11 +491,13 @@ class BoschComSelectDhwOperationMode(CoordinatorEntity, SelectEntity):
             value = data.get(key)
             return value if value is not None else default
 
-        for entry in self.coordinator.data.dhw_circuits:
-            if entry.get("id") == "/dhwCircuits/" + self._attr_name:
-                operationMode = safe_get(entry["operationMode"], "value")
+        operation_mode = None
 
-        self._attr_current_option = operationMode
+        for entry in self.coordinator.data.dhw_circuits:
+            if entry.get("id") == "/dhwCircuits/" + self.field:
+                operation_mode = safe_get(entry["operationMode"], "value")
+
+        self._attr_current_option = operation_mode
         self.async_write_ha_state()
 
 
@@ -513,7 +518,7 @@ class BoschComSelectDhwCurrentTemp(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-temp"
-        self._attr_name = field + "_temp"
+        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
@@ -580,15 +585,16 @@ class BoschComSelectHcOperationMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field
+        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
+        self.field = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
         await self._coordinator.bhc.async_put_hc_operation_mode(
-            self._coordinator.data.device["deviceId"], self._attr_name, option
+            self._coordinator.data.device["deviceId"], self.field, option
         )
 
         await self._coordinator.async_request_refresh()
@@ -602,11 +608,13 @@ class BoschComSelectHcOperationMode(CoordinatorEntity, SelectEntity):
             value = data.get(key)
             return value if value is not None else default
 
-        for entry in self.coordinator.data.heating_circuits:
-            if entry.get("id") == "/heatingCircuits/" + self._attr_name:
-                operationMode = safe_get(entry["operationMode"], "value")
+        operation_mode = None
 
-        return operationMode
+        for entry in self.coordinator.data.heating_circuits:
+            if entry.get("id") == "/heatingCircuits/" + self.field:
+                operation_mode = safe_get(entry["operationMode"], "value")
+
+        return operation_mode
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -617,11 +625,13 @@ class BoschComSelectHcOperationMode(CoordinatorEntity, SelectEntity):
             value = data.get(key)
             return value if value is not None else default
 
-        for entry in self.coordinator.data.heating_circuits:
-            if entry.get("id") == "/heatingCircuits/" + self._attr_name:
-                operationMode = safe_get(entry["operationMode"], "value")
+        operation_mode = None
 
-        self._attr_current_option = operationMode
+        for entry in self.coordinator.data.heating_circuits:
+            if entry.get("id") == "/heatingCircuits/" + self.field:
+                operation_mode = safe_get(entry["operationMode"], "value")
+
+        self._attr_current_option = operation_mode
         self.async_write_ha_state()
 
 
@@ -642,7 +652,7 @@ class BoschComSelectHcSuwiMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-suwi"
-        self._attr_name = field + "_suwi"
+        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
@@ -705,7 +715,7 @@ class BoschComSelectHcHeatcoolMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-heatcool"
-        self._attr_name = field + "_heatcool"
+        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
@@ -767,7 +777,7 @@ class BoschComSelectHolidayMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_key = "holiday_mode"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field
+        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
@@ -811,7 +821,7 @@ class BoschComSelectAwayMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_key = "away_mode"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field
+        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
@@ -852,9 +862,10 @@ class BoschComSelectHcNightSwitchMode(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "hc_night_switch_mode"
+        self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-nightswitch"
-        self._attr_name = field + "_nightswitch"
+        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
@@ -901,9 +912,10 @@ class BoschComSelectHcControl(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "hc_control"
+        self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-control"
-        self._attr_name = field + "_control"
+        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
@@ -948,9 +960,10 @@ class BoschComSelectVentilationSummerEnable(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "ventilation_summer_enable"
+        self._attr_translation_placeholders = {"zone": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-summerbypass-enable"
-        self._attr_name = field + "_summerbypass_enable"
+        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues

--- a/custom_components/bosch_homecom/select.py
+++ b/custom_components/bosch_homecom/select.py
@@ -8,7 +8,6 @@ from homeassistant.core import callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import get_field_number
 from .coordinator import (
     BoschComModuleCoordinatorCommodule,
     BoschComModuleCoordinatorK40,
@@ -449,7 +448,7 @@ class BoschComSelectDhwOperationMode(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "dhw_operation_mode"
-        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
+        self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._coordinator = coordinator
@@ -516,7 +515,7 @@ class BoschComSelectDhwCurrentTemp(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "dhw_current_temp"
-        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
+        self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-temp"
         self._coordinator = coordinator
@@ -583,7 +582,7 @@ class BoschComSelectHcOperationMode(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "hc_operation_mode"
-        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
+        self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._coordinator = coordinator
@@ -650,7 +649,7 @@ class BoschComSelectHcSuwiMode(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "hc_suwi_mode"
-        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
+        self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-suwi"
         self._coordinator = coordinator
@@ -713,7 +712,7 @@ class BoschComSelectHcHeatcoolMode(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "hc_heatcool_mode"
-        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
+        self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-heatcool"
         self._coordinator = coordinator
@@ -863,7 +862,7 @@ class BoschComSelectHcNightSwitchMode(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "hc_night_switch_mode"
-        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
+        self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-nightswitch"
         self._coordinator = coordinator
@@ -913,7 +912,7 @@ class BoschComSelectHcControl(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "hc_control"
-        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
+        self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-control"
         self._coordinator = coordinator
@@ -961,7 +960,7 @@ class BoschComSelectVentilationSummerEnable(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "ventilation_summer_enable"
-        self._attr_translation_placeholders = {"zone": get_field_number(field)}
+        self._attr_translation_placeholders = {"zone": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-summerbypass-enable"
         self._coordinator = coordinator

--- a/custom_components/bosch_homecom/select.py
+++ b/custom_components/bosch_homecom/select.py
@@ -212,7 +212,7 @@ class BoschComSelectAirflowHorizontal(CoordinatorEntity, SelectEntity):
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._coordinator = coordinator
         self._attr_should_poll = False
-            self._attr_suggested_object_id = field
+        self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -285,7 +285,7 @@ class BoschComSelectAirflowVertical(CoordinatorEntity, SelectEntity):
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._coordinator = coordinator
         self._attr_should_poll = False
-            self._attr_suggested_object_id = field
+        self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -358,7 +358,7 @@ class BoschComSelectProgram(CoordinatorEntity, SelectEntity):
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._coordinator = coordinator
         self._attr_should_poll = False
-            self._attr_suggested_object_id = field
+        self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -455,7 +455,7 @@ class BoschComSelectDhwOperationMode(CoordinatorEntity, SelectEntity):
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
-            self._attr_suggested_object_id = field
+        self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -522,7 +522,7 @@ class BoschComSelectDhwCurrentTemp(CoordinatorEntity, SelectEntity):
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
-            self._attr_suggested_object_id = field + "_temp"
+        self._attr_suggested_object_id = field + "_temp"
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -589,7 +589,7 @@ class BoschComSelectHcOperationMode(CoordinatorEntity, SelectEntity):
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
-            self._attr_suggested_object_id = field
+        self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -656,7 +656,7 @@ class BoschComSelectHcSuwiMode(CoordinatorEntity, SelectEntity):
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
-            self._attr_suggested_object_id = field + "_suwi"
+        self._attr_suggested_object_id = field + "_suwi"
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -719,7 +719,7 @@ class BoschComSelectHcHeatcoolMode(CoordinatorEntity, SelectEntity):
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
-            self._attr_suggested_object_id = field + "_heatcool"
+        self._attr_suggested_object_id = field + "_heatcool"
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -780,7 +780,7 @@ class BoschComSelectHolidayMode(CoordinatorEntity, SelectEntity):
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
-            self._attr_suggested_object_id = field
+        self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -824,7 +824,7 @@ class BoschComSelectAwayMode(CoordinatorEntity, SelectEntity):
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
-            self._attr_suggested_object_id = field
+        self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -869,7 +869,7 @@ class BoschComSelectHcNightSwitchMode(CoordinatorEntity, SelectEntity):
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
-            self._attr_suggested_object_id = field + "_nightswitch"
+        self._attr_suggested_object_id = field + "_nightswitch"
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -919,7 +919,7 @@ class BoschComSelectHcControl(CoordinatorEntity, SelectEntity):
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
-            self._attr_suggested_object_id = field + "_control"
+        self._attr_suggested_object_id = field + "_control"
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -967,7 +967,7 @@ class BoschComSelectVentilationSummerEnable(CoordinatorEntity, SelectEntity):
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
-            self._attr_suggested_object_id = field + "_summerbypass_enable"
+        self._attr_suggested_object_id = field + "_summerbypass_enable"
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""

--- a/custom_components/bosch_homecom/select.py
+++ b/custom_components/bosch_homecom/select.py
@@ -210,9 +210,9 @@ class BoschComSelectAirflowHorizontal(CoordinatorEntity, SelectEntity):
         self._attr_translation_key = "airflow_horizontal"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
+        self._attr_suggested_object_id = field
         self._coordinator = coordinator
         self._attr_should_poll = False
-        self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -283,9 +283,9 @@ class BoschComSelectAirflowVertical(CoordinatorEntity, SelectEntity):
         self._attr_translation_key = "airflow_vertical"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
+        self._attr_suggested_object_id = field
         self._coordinator = coordinator
         self._attr_should_poll = False
-        self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -356,9 +356,9 @@ class BoschComSelectProgram(CoordinatorEntity, SelectEntity):
         self._attr_translation_key = "program"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
+        self._attr_suggested_object_id = field
         self._coordinator = coordinator
         self._attr_should_poll = False
-        self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -451,11 +451,11 @@ class BoschComSelectDhwOperationMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
+        self._attr_suggested_object_id = field
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
-        self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -474,13 +474,13 @@ class BoschComSelectDhwOperationMode(CoordinatorEntity, SelectEntity):
             value = data.get(key)
             return value if value is not None else default
 
-        operation_mode = None
+        operationMode = None
 
         for entry in self.coordinator.data.dhw_circuits:
             if entry.get("id") == "/dhwCircuits/" + self.field:
-                operation_mode = safe_get(entry["operationMode"], "value")
+                operationMode = safe_get(entry["operationMode"], "value")
 
-        return operation_mode
+        return operationMode
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -491,13 +491,13 @@ class BoschComSelectDhwOperationMode(CoordinatorEntity, SelectEntity):
             value = data.get(key)
             return value if value is not None else default
 
-        operation_mode = None
+        operationMode = None
 
         for entry in self.coordinator.data.dhw_circuits:
             if entry.get("id") == "/dhwCircuits/" + self.field:
-                operation_mode = safe_get(entry["operationMode"], "value")
+                operationMode = safe_get(entry["operationMode"], "value")
 
-        self._attr_current_option = operation_mode
+        self._attr_current_option = operationMode
         self.async_write_ha_state()
 
 
@@ -518,11 +518,11 @@ class BoschComSelectDhwCurrentTemp(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-temp"
+        self._attr_suggested_object_id = field + "_temp"
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
-        self._attr_suggested_object_id = field + "_temp"
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -585,11 +585,11 @@ class BoschComSelectHcOperationMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
+        self._attr_suggested_object_id = field
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
-        self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -608,13 +608,13 @@ class BoschComSelectHcOperationMode(CoordinatorEntity, SelectEntity):
             value = data.get(key)
             return value if value is not None else default
 
-        operation_mode = None
+        operationMode = None
 
         for entry in self.coordinator.data.heating_circuits:
             if entry.get("id") == "/heatingCircuits/" + self.field:
-                operation_mode = safe_get(entry["operationMode"], "value")
+                operationMode = safe_get(entry["operationMode"], "value")
 
-        return operation_mode
+        return operationMode
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -625,13 +625,13 @@ class BoschComSelectHcOperationMode(CoordinatorEntity, SelectEntity):
             value = data.get(key)
             return value if value is not None else default
 
-        operation_mode = None
+        operationMode = None
 
         for entry in self.coordinator.data.heating_circuits:
             if entry.get("id") == "/heatingCircuits/" + self.field:
-                operation_mode = safe_get(entry["operationMode"], "value")
+                operationMode = safe_get(entry["operationMode"], "value")
 
-        self._attr_current_option = operation_mode
+        self._attr_current_option = operationMode
         self.async_write_ha_state()
 
 
@@ -652,11 +652,11 @@ class BoschComSelectHcSuwiMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-suwi"
+        self._attr_suggested_object_id = field + "_suwi"
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
-        self._attr_suggested_object_id = field + "_suwi"
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -715,11 +715,11 @@ class BoschComSelectHcHeatcoolMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-heatcool"
+        self._attr_suggested_object_id = field + "_heatcool"
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
-        self._attr_suggested_object_id = field + "_heatcool"
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -777,10 +777,10 @@ class BoschComSelectHolidayMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_key = "holiday_mode"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
+        self._attr_suggested_object_id = field
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
-        self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -821,10 +821,10 @@ class BoschComSelectAwayMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_key = "away_mode"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
+        self._attr_suggested_object_id = field
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
-        self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -865,11 +865,11 @@ class BoschComSelectHcNightSwitchMode(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-nightswitch"
+        self._attr_suggested_object_id = field + "_nightswitch"
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
-        self._attr_suggested_object_id = field + "_nightswitch"
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -915,11 +915,11 @@ class BoschComSelectHcControl(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-control"
+        self._attr_suggested_object_id = field + "_control"
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
-        self._attr_suggested_object_id = field + "_control"
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -963,11 +963,11 @@ class BoschComSelectVentilationSummerEnable(CoordinatorEntity, SelectEntity):
         self._attr_translation_placeholders = {"zone": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-summerbypass-enable"
+        self._attr_suggested_object_id = field + "_summerbypass_enable"
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
-        self._attr_suggested_object_id = field + "_summerbypass_enable"
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -1134,6 +1134,7 @@ class BoschComCommoduleChargingStrategySelect(CoordinatorEntity, SelectEntity):
         self._attr_translation_key = "wb_charging_strategy"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{cp_id}-charging-strategy"
+        self._attr_suggested_object_id = cp_id + "_charging_strategy"
         self._coordinator = coordinator
         self._cp_id = cp_id
         self._attr_options = allowed_values

--- a/custom_components/bosch_homecom/select.py
+++ b/custom_components/bosch_homecom/select.py
@@ -212,6 +212,7 @@ class BoschComSelectAirflowHorizontal(CoordinatorEntity, SelectEntity):
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._coordinator = coordinator
         self._attr_should_poll = False
+            self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -284,6 +285,7 @@ class BoschComSelectAirflowVertical(CoordinatorEntity, SelectEntity):
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._coordinator = coordinator
         self._attr_should_poll = False
+            self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -356,6 +358,7 @@ class BoschComSelectProgram(CoordinatorEntity, SelectEntity):
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._coordinator = coordinator
         self._attr_should_poll = False
+            self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -452,6 +455,7 @@ class BoschComSelectDhwOperationMode(CoordinatorEntity, SelectEntity):
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
+            self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -518,6 +522,7 @@ class BoschComSelectDhwCurrentTemp(CoordinatorEntity, SelectEntity):
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
+            self._attr_suggested_object_id = field + "_temp"
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -584,6 +589,7 @@ class BoschComSelectHcOperationMode(CoordinatorEntity, SelectEntity):
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
+            self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -650,6 +656,7 @@ class BoschComSelectHcSuwiMode(CoordinatorEntity, SelectEntity):
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
+            self._attr_suggested_object_id = field + "_suwi"
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -712,6 +719,7 @@ class BoschComSelectHcHeatcoolMode(CoordinatorEntity, SelectEntity):
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
+            self._attr_suggested_object_id = field + "_heatcool"
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -772,6 +780,7 @@ class BoschComSelectHolidayMode(CoordinatorEntity, SelectEntity):
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
+            self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -815,6 +824,7 @@ class BoschComSelectAwayMode(CoordinatorEntity, SelectEntity):
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._attr_options = allowedValues
+            self._attr_suggested_object_id = field
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -859,6 +869,7 @@ class BoschComSelectHcNightSwitchMode(CoordinatorEntity, SelectEntity):
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
+            self._attr_suggested_object_id = field + "_nightswitch"
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -908,6 +919,7 @@ class BoschComSelectHcControl(CoordinatorEntity, SelectEntity):
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
+            self._attr_suggested_object_id = field + "_control"
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
@@ -955,6 +967,7 @@ class BoschComSelectVentilationSummerEnable(CoordinatorEntity, SelectEntity):
         self._attr_should_poll = False
         self._attr_options = allowedValues
         self.field = field
+            self._attr_suggested_object_id = field + "_summerbypass_enable"
 
     async def async_select_option(self, option: str) -> None:
         """Set the option."""

--- a/custom_components/bosch_homecom/select.py
+++ b/custom_components/bosch_homecom/select.py
@@ -8,6 +8,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .const import get_field_number
 from .coordinator import (
     BoschComModuleCoordinatorCommodule,
     BoschComModuleCoordinatorK40,
@@ -448,7 +449,7 @@ class BoschComSelectDhwOperationMode(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "dhw_operation_mode"
-        self._attr_translation_placeholders = {"circuit": field}
+        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._coordinator = coordinator
@@ -515,7 +516,7 @@ class BoschComSelectDhwCurrentTemp(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "dhw_current_temp"
-        self._attr_translation_placeholders = {"circuit": field}
+        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-temp"
         self._coordinator = coordinator
@@ -582,7 +583,7 @@ class BoschComSelectHcOperationMode(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "hc_operation_mode"
-        self._attr_translation_placeholders = {"circuit": field}
+        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._coordinator = coordinator
@@ -649,7 +650,7 @@ class BoschComSelectHcSuwiMode(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "hc_suwi_mode"
-        self._attr_translation_placeholders = {"circuit": field}
+        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-suwi"
         self._coordinator = coordinator
@@ -712,7 +713,7 @@ class BoschComSelectHcHeatcoolMode(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "hc_heatcool_mode"
-        self._attr_translation_placeholders = {"circuit": field}
+        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-heatcool"
         self._coordinator = coordinator
@@ -862,7 +863,7 @@ class BoschComSelectHcNightSwitchMode(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "hc_night_switch_mode"
-        self._attr_translation_placeholders = {"circuit": field}
+        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-nightswitch"
         self._coordinator = coordinator
@@ -912,7 +913,7 @@ class BoschComSelectHcControl(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "hc_control"
-        self._attr_translation_placeholders = {"circuit": field}
+        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-control"
         self._coordinator = coordinator
@@ -960,7 +961,7 @@ class BoschComSelectVentilationSummerEnable(CoordinatorEntity, SelectEntity):
         """Initialize select entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "ventilation_summer_enable"
-        self._attr_translation_placeholders = {"zone": field}
+        self._attr_translation_placeholders = {"zone": get_field_number(field)}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}-summerbypass-enable"
         self._coordinator = coordinator

--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -29,7 +29,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import get_field_number, BOSCH_SENSOR_DESCRIPTORS
+from .const import BOSCH_SENSOR_DESCRIPTORS
 from .coordinator import (
     BoschComModuleCoordinatorCommodule,
     BoschComModuleCoordinatorIcom,
@@ -538,7 +538,7 @@ class BoschComSensorDhw(BoschComSensorBase):
             icon="mdi:water-boiler",
         )
         self._attr_translation_key = "dhw"
-        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
+        self._attr_translation_placeholders = {"circuit": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         del self._attr_name
         self._attr_should_poll = False
@@ -635,7 +635,7 @@ class BoschComSensorHc(BoschComSensorBase):
             icon="mdi:heating-coil",
         )
         self._attr_translation_key = "hc"
-        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
+        self._attr_translation_placeholders = {"circuit": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         del self._attr_name
         self._attr_should_poll = False
@@ -757,7 +757,7 @@ class BoschComSensorVentilation(BoschComSensorBase):
             icon="mdi:fan",
         )
         self._attr_translation_key = "ventilation"
-        self._attr_translation_placeholders = {"zone": get_field_number(field)}
+        self._attr_translation_placeholders = {"zone": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         del self._attr_name
         self._attr_should_poll = False
@@ -1126,7 +1126,7 @@ class BoschComSensorDhwWddw2(BoschComSensorBase):
             icon="mdi:water-boiler",
         )
         self._attr_translation_key = "dhw"
-        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
+        self._attr_translation_placeholders = {"circuit": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         del self._attr_name
         self._attr_should_poll = False

--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -425,12 +425,11 @@ class BoschComSensorNotificationsRac(BoschComSensorBase):
         )
         self._attr_translation_key = "notifications"
         self._attr_unique_id = f"{coordinator.unique_id}-notifications"
-        self._attr_name = None
+        del self._attr_name
         self._attr_should_poll = False
 
         _LOGGER.debug(
-            "Init BoschComSensorNotificationsRac: name=%s, unique_id=%s",
-            self._attr_name,
+            "Init BoschComSensorNotificationsRac: unique_id=%s",
             self._attr_unique_id,
         )
 
@@ -460,12 +459,11 @@ class BoschComSensorNotificationsK40(BoschComSensorBase):
         )
         self._attr_translation_key = "notifications"
         self._attr_unique_id = f"{coordinator.unique_id}-notifications"
-        self._attr_name = None
+        del self._attr_name
         self._attr_should_poll = False
 
         _LOGGER.debug(
-            "Init BoschComSensorNotificationsK40: name=%s, unique_id=%s",
-            self._attr_name,
+            "Init BoschComSensorNotificationsK40: unique_id=%s",
             self._attr_unique_id,
         )
 
@@ -499,12 +497,11 @@ class BoschComSensorNotificationsWddw2(BoschComSensorBase):
         )
         self._attr_translation_key = "notifications"
         self._attr_unique_id = f"{coordinator.unique_id}-notifications"
-        self._attr_name = None
+        del self._attr_name
         self._attr_should_poll = False
 
         _LOGGER.debug(
-            "Init BoschComSensorNotificationsWddw2: name=%s, unique_id=%s",
-            self._attr_name,
+            "Init BoschComSensorNotificationsWddw2: unique_id=%s",
             self._attr_unique_id,
         )
 
@@ -540,7 +537,7 @@ class BoschComSensorDhw(BoschComSensorBase):
         self._attr_translation_key = "dhw"
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = None
+        del self._attr_name
         self._attr_should_poll = False
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
@@ -548,8 +545,8 @@ class BoschComSensorDhw(BoschComSensorBase):
         self.field = field
 
         _LOGGER.debug(
-            "Init BoschComSensorDhw: name=%s, unique_id=%s",
-            self._attr_name,
+            "Init BoschComSensorDhw: translation_key=%s, unique_id=%s",
+            self._attr_translation_key,
             self._attr_unique_id,
         )
 
@@ -636,15 +633,15 @@ class BoschComSensorHc(BoschComSensorBase):
         self._attr_translation_key = "hc"
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = None
+        del self._attr_name
         self._attr_should_poll = False
         self._attr_device_class = SensorDeviceClass.ENUM
         self._attr_options = ["off", "manual", "auto"]
         self.field = field
 
         _LOGGER.debug(
-            "Init BoschComSensorHc: name=%s, unique_id=%s",
-            self._attr_name,
+            "Init BoschComSensorHc: translation_key=%s, unique_id=%s",
+            self._attr_translation_key,
             self._attr_unique_id,
         )
 
@@ -757,15 +754,15 @@ class BoschComSensorVentilation(BoschComSensorBase):
         self._attr_translation_key = "ventilation"
         self._attr_translation_placeholders = {"zone": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = None
+        del self._attr_name
         self._attr_should_poll = False
         self._attr_device_class = SensorDeviceClass.ENUM
         self._attr_options = ["off", "min", "red", "nom", "max", "dem"]
         self.field = field
 
         _LOGGER.debug(
-            "Init BoschComSensorVentilation: name=%s, unique_id=%s",
-            self._attr_name,
+            "Init BoschComSensorVentilation: translation_key=%s, unique_id=%s",
+            self._attr_translation_key,
             self._attr_unique_id,
         )
 
@@ -1125,13 +1122,13 @@ class BoschComSensorDhwWddw2(BoschComSensorBase):
         self._attr_translation_key = "dhw"
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = None
+        del self._attr_name
         self._attr_should_poll = False
         self.field = field
 
         _LOGGER.debug(
-            "Init BoschComSensorDhw: name=%s, unique_id=%s",
-            self._attr_name,
+            "Init BoschComSensorDhwWddw2: translation_key=%s, unique_id=%s",
+            self._attr_translation_key,
             self._attr_unique_id,
         )
 

--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -876,8 +876,9 @@ class BoschComSensorOutdoorTemp(BoschComSensorBase):
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_translation_key = "outdoor_temp"
+        del self._attr_name
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field + "_sensor"
+        self._attr_suggested_object_id = field + "_sensor"
         self._attr_should_poll = False
         self.field = field
 
@@ -928,7 +929,8 @@ class BoschComSensorHs(BoschComSensorBase):
         )
         self._attr_translation_key = "hs"
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field
+        del self._attr_name
+        self._attr_suggested_object_id = field
         self._attr_should_poll = False
 
         _LOGGER.debug(
@@ -1129,6 +1131,7 @@ class BoschComSensorDhwWddw2(BoschComSensorBase):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         del self._attr_name
+        self._attr_suggested_object_id = field + "_sensor"
         self._attr_should_poll = False
         self.field = field
 
@@ -1495,7 +1498,8 @@ class BoschComSensorIndoorHumidity(BoschComSensorBase):
         )
         self._attr_translation_key = "indoor_humidity"
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field
+        del self._attr_name
+        self._attr_suggested_object_id = field
         self._attr_should_poll = False
         self._attr_device_class = SensorDeviceClass.HUMIDITY
         self._attr_state_class = SensorStateClass.MEASUREMENT
@@ -1531,7 +1535,8 @@ class BoschComSensorFlameIndication(BoschComSensorBase):
         )
         self._attr_translation_key = "flame_indication"
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field
+        del self._attr_name
+        self._attr_suggested_object_id = field
         self._attr_should_poll = False
 
     @property
@@ -1564,7 +1569,8 @@ class BoschComSensorEnergyHistory(BoschComSensorBase):
         )
         self._attr_translation_key = "energy_history"
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field
+        del self._attr_name
+        self._attr_suggested_object_id = field
         self._attr_should_poll = False
         self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_unit_of_measurement = "kWh"
@@ -1639,7 +1645,8 @@ class BoschComSensorEnergyHistoryHourly(BoschComSensorBase):
         )
         self._attr_translation_key = "energy_history_hourly"
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field
+        del self._attr_name
+        self._attr_suggested_object_id = field
         self._attr_should_poll = False
         self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_unit_of_measurement = "kWh"
@@ -1769,7 +1776,7 @@ class BoschComThermostatRoomTempSensor(_ThermostatDeviceSensorBase):
             icon="mdi:thermometer",
         )
         self._attr_translation_key = "thermostat_room_temp"
-        self._attr_name = f"{dev_id}_room_temp"
+        self._suggested_object_id = f"{dev_id}_room_temp"
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_state_class = SensorStateClass.MEASUREMENT
@@ -1799,7 +1806,8 @@ class BoschComThermostatHumiditySensor(_ThermostatDeviceSensorBase):
             icon="mdi:water-percent",
         )
         self._attr_translation_key = "thermostat_humidity"
-        self._attr_name = f"{dev_id}_humidity"
+        del self._attr_name
+        self._attr_suggested_object_id = f"{dev_id}_humidity"
         self._attr_device_class = SensorDeviceClass.HUMIDITY
         self._attr_native_unit_of_measurement = "%"
         self._attr_state_class = SensorStateClass.MEASUREMENT
@@ -1829,7 +1837,8 @@ class BoschComThermostatSetpointSensor(_ThermostatDeviceSensorBase):
             icon="mdi:thermostat",
         )
         self._attr_translation_key = "thermostat_setpoint"
-        self._attr_name = f"{dev_id}_setpoint"
+        del self._attr_name
+        self._attr_suggested_object_id = f"{dev_id}_setpoint"
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_state_class = SensorStateClass.MEASUREMENT
@@ -1859,7 +1868,8 @@ class BoschComThermostatBatterySensor(_ThermostatDeviceSensorBase):
             icon="mdi:battery",
         )
         self._attr_translation_key = "thermostat_battery"
-        self._attr_name = f"{dev_id}_battery"
+        del self._attr_name
+        self._attr_suggested_object_id = f"{dev_id}_battery"
         self._attr_device_class = SensorDeviceClass.BATTERY
         self._attr_native_unit_of_measurement = "%"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -1889,7 +1899,8 @@ class BoschComThermostatSignalSensor(_ThermostatDeviceSensorBase):
             icon="mdi:signal",
         )
         self._attr_translation_key = "thermostat_signal"
-        self._attr_name = f"{dev_id}_signal"
+        del self._attr_name
+        self._attr_suggested_object_id = f"{dev_id}_signal"
         self._attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
         self._attr_native_unit_of_measurement = "dBm"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -1973,7 +1984,8 @@ class BoschComCommoduleStateSensor(_CommoduleSensorBase):
             coordinator, config_entry, cp_id, "wb_state", icon="mdi:ev-station"
         )
         self._attr_translation_key = "wb_state"
-        self._attr_name = f"{cp_id}_state"
+        del self._attr_name
+        self._attr_suggested_object_id = f"{cp_id}_state"
         self._attr_device_class = SensorDeviceClass.ENUM
         self._attr_options = self._WB_STATE_OPTIONS
 
@@ -1997,7 +2009,8 @@ class BoschComCommodulePowerSensor(_CommoduleSensorBase):
         """Initialize power sensor."""
         super().__init__(coordinator, config_entry, cp_id, "wb_power")
         self._attr_translation_key = "wb_power"
-        self._attr_name = f"{cp_id}_power"
+        del self._attr_name
+        self._attr_suggested_object_id = f"{cp_id}_power"
         self._attr_device_class = SensorDeviceClass.POWER
         self._attr_native_unit_of_measurement = "W"
         self._attr_state_class = SensorStateClass.MEASUREMENT
@@ -2022,7 +2035,8 @@ class BoschComCommoduleEnergySensor(_CommoduleSensorBase):
         """Initialize energy sensor."""
         super().__init__(coordinator, config_entry, cp_id, "wb_energy_total")
         self._attr_translation_key = "wb_energy_total"
-        self._attr_name = f"{cp_id}_energy_total"
+        del self._attr_name
+        self._attr_suggested_object_id = f"{cp_id}_energy_total"
         self._attr_device_class = SensorDeviceClass.ENERGY
         self._attr_native_unit_of_measurement = "kWh"
         self._attr_state_class = SensorStateClass.TOTAL_INCREASING
@@ -2047,7 +2061,8 @@ class BoschComCommoduleTempSensor(_CommoduleSensorBase):
         """Initialize temperature sensor."""
         super().__init__(coordinator, config_entry, cp_id, "wb_temperature")
         self._attr_translation_key = "wb_temperature"
-        self._attr_name = f"{cp_id}_temperature"
+        del self._attr_name
+        self._attr_suggested_object_id = f"{cp_id}_temperature"
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_state_class = SensorStateClass.MEASUREMENT
@@ -2074,7 +2089,8 @@ class BoschComCommodulePhasesSensor(_CommoduleSensorBase):
             coordinator, config_entry, cp_id, "wb_phases", icon="mdi:sine-wave"
         )
         self._attr_translation_key = "wb_phases"
-        self._attr_name = f"{cp_id}_phases"
+        del self._attr_name
+        self._attr_suggested_object_id = f"{cp_id}_phases"
 
     @property
     def state(self):
@@ -2129,7 +2145,8 @@ class BoschComCommoduleChargelogSensor(_CommoduleSensorBase):
             coordinator, config_entry, cp_id, "wb_chargelog", icon="mdi:history"
         )
         self._attr_translation_key = "wb_chargelog"
-        self._attr_name = f"{cp_id}_chargelog"
+        del self._attr_name
+        self._attr_suggested_object_id = f"{cp_id}_chargelog"
         self._attr_device_class = SensorDeviceClass.TIMESTAMP
 
     def _get_sessions(self):

--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -389,18 +389,16 @@ async def async_setup_entry(
 class BoschComSensorBase(CoordinatorEntity, SensorEntity):
     """Boshcom sensor base class."""
 
-    def __init__(self, coordinator, config_entry, name, unique_id, icon=None) -> None:
+    def __init__(self, coordinator, config_entry, unique_id, icon=None) -> None:
         """Init base class."""
         super().__init__(coordinator)
         self.config_entry = config_entry
-        self._attr_name = name
         self._attr_unique_id = unique_id
         self._attr_icon = icon
         self._attr_device_info = coordinator.device_info
 
         _LOGGER.debug(
-            "Init base class: name=%s, unique_id=%s",
-            self._attr_name,
+            "Init base class: unique_id=%s",
             self._attr_unique_id,
         )
 
@@ -419,18 +417,17 @@ class BoschComSensorNotificationsRac(BoschComSensorBase):
         super().__init__(
             coordinator=coordinator,
             config_entry=config_entry,
-            name="_notifications",
             unique_id=f"{coordinator.unique_id}-notifications",
             icon="mdi:bell",
         )
         self._attr_translation_key = "notifications"
         self._attr_unique_id = f"{coordinator.unique_id}-notifications"
         self._attr_suggested_object_id = "notifications"
-        del self._attr_name
         self._attr_should_poll = False
 
         _LOGGER.debug(
-            "Init BoschComSensorNotificationsRac: unique_id=%s",
+            "Init BoschComSensorNotificationsRac: translation_key=%s, unique_id=%s",
+            self._attr_translation_key,
             self._attr_unique_id,
         )
 
@@ -454,18 +451,17 @@ class BoschComSensorNotificationsK40(BoschComSensorBase):
         super().__init__(
             coordinator=coordinator,
             config_entry=config_entry,
-            name="_notifications",
             unique_id=f"{coordinator.unique_id}-notifications",
             icon="mdi:bell",
         )
         self._attr_translation_key = "notifications"
         self._attr_unique_id = f"{coordinator.unique_id}-notifications"
         self._attr_suggested_object_id = "notifications"
-        del self._attr_name
         self._attr_should_poll = False
 
         _LOGGER.debug(
-            "Init BoschComSensorNotificationsK40: unique_id=%s",
+            "Init BoschComSensorNotificationsK40: translation_key=%s, unique_id=%s",
+            self._attr_translation_key,
             self._attr_unique_id,
         )
 
@@ -493,18 +489,17 @@ class BoschComSensorNotificationsWddw2(BoschComSensorBase):
         super().__init__(
             coordinator=coordinator,
             config_entry=config_entry,
-            name="_notifications",
             unique_id=f"{coordinator.unique_id}-notifications",
             icon="mdi:bell",
         )
         self._attr_translation_key = "notifications"
         self._attr_unique_id = f"{coordinator.unique_id}-notifications"
         self._attr_suggested_object_id = "notifications"
-        del self._attr_name
         self._attr_should_poll = False
 
         _LOGGER.debug(
-            "Init BoschComSensorNotificationsWddw2: unique_id=%s",
+            "Init BoschComSensorNotificationsWddw2: translation_key=%s, unique_id=%s",
+            self._attr_translation_key,
             self._attr_unique_id,
         )
 
@@ -533,14 +528,12 @@ class BoschComSensorDhw(BoschComSensorBase):
         super().__init__(
             coordinator=coordinator,
             config_entry=config_entry,
-            name=field + "_sensor",
             unique_id=f"{coordinator.unique_id}-{field}-sensor",
             icon="mdi:water-boiler",
         )
         self._attr_translation_key = "dhw"
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        del self._attr_name
         self._attr_should_poll = False
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_suggested_object_id = field + "_sensor"
@@ -630,14 +623,12 @@ class BoschComSensorHc(BoschComSensorBase):
         super().__init__(
             coordinator=coordinator,
             config_entry=config_entry,
-            name=field + "_sensor",
             unique_id=f"{coordinator.unique_id}-{field}-sensor",
             icon="mdi:heating-coil",
         )
         self._attr_translation_key = "hc"
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        del self._attr_name
         self._attr_should_poll = False
         self._attr_device_class = SensorDeviceClass.ENUM
         self._attr_suggested_object_id = f"{field}_sensor"
@@ -752,14 +743,12 @@ class BoschComSensorVentilation(BoschComSensorBase):
         super().__init__(
             coordinator=coordinator,
             config_entry=config_entry,
-            name=field + "_sensor",
             unique_id=f"{coordinator.unique_id}-{field}-sensor",
             icon="mdi:fan",
         )
         self._attr_translation_key = "ventilation"
         self._attr_translation_placeholders = {"zone": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        del self._attr_name
         self._attr_should_poll = False
         self._attr_device_class = SensorDeviceClass.ENUM
         self._attr_suggested_object_id = field + "_sensor"
@@ -868,7 +857,6 @@ class BoschComSensorOutdoorTemp(BoschComSensorBase):
         super().__init__(
             coordinator=coordinator,
             config_entry=config_entry,
-            name=field + "_sensor",
             unique_id=f"{coordinator.unique_id}-{field}-sensor",
             icon="mdi:sun-thermometer",
         )
@@ -876,15 +864,14 @@ class BoschComSensorOutdoorTemp(BoschComSensorBase):
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_translation_key = "outdoor_temp"
-        del self._attr_name
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._attr_suggested_object_id = field + "_sensor"
         self._attr_should_poll = False
         self.field = field
 
         _LOGGER.debug(
-            "Init BoschComSensorOutdoorTemp: name=%s, unique_id=%s",
-            self._attr_name,
+            "Init BoschComSensorOutdoorTemp: translation_key=%s, unique_id=%s",
+            self._attr_translation_key,
             self._attr_unique_id,
         )
 
@@ -923,19 +910,17 @@ class BoschComSensorHs(BoschComSensorBase):
         super().__init__(
             coordinator=coordinator,
             config_entry=config_entry,
-            name=field,
             unique_id=f"{coordinator.unique_id}-{field}",
             icon="mdi:heat-wave",
         )
         self._attr_translation_key = "hs"
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        del self._attr_name
         self._attr_suggested_object_id = field
         self._attr_should_poll = False
 
         _LOGGER.debug(
-            "Init BoschComSensorHS: name=%s, unique_id=%s",
-            self._attr_name,
+            "Init BoschComSensorHS: translation_key=%s, unique_id=%s",
+            self._attr_translation_key,
             self._attr_unique_id,
         )
 
@@ -1123,14 +1108,12 @@ class BoschComSensorDhwWddw2(BoschComSensorBase):
         super().__init__(
             coordinator=coordinator,
             config_entry=config_entry,
-            name=field + "_sensor",
             unique_id=f"{coordinator.unique_id}-{field}-sensor",
             icon="mdi:water-boiler",
         )
         self._attr_translation_key = "dhw"
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        del self._attr_name
         self._attr_suggested_object_id = field + "_sensor"
         self._attr_should_poll = False
         self.field = field
@@ -1326,7 +1309,6 @@ class BoschComDerivedDeltaTSensor(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.unique_id}-{unique_suffix}"
         self._attr_device_info = coordinator.device_info
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
-        # self._attr_device_class = "temperature"
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_state_class = "measurement"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -1492,13 +1474,11 @@ class BoschComSensorIndoorHumidity(BoschComSensorBase):
         super().__init__(
             coordinator=coordinator,
             config_entry=config_entry,
-            name=field,
             unique_id=f"{coordinator.unique_id}-{field}",
             icon="mdi:water-percent",
         )
         self._attr_translation_key = "indoor_humidity"
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        del self._attr_name
         self._attr_suggested_object_id = field
         self._attr_should_poll = False
         self._attr_device_class = SensorDeviceClass.HUMIDITY
@@ -1529,13 +1509,11 @@ class BoschComSensorFlameIndication(BoschComSensorBase):
         super().__init__(
             coordinator=coordinator,
             config_entry=config_entry,
-            name=field,
             unique_id=f"{coordinator.unique_id}-{field}",
             icon="mdi:fire",
         )
         self._attr_translation_key = "flame_indication"
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        del self._attr_name
         self._attr_suggested_object_id = field
         self._attr_should_poll = False
 
@@ -1563,13 +1541,11 @@ class BoschComSensorEnergyHistory(BoschComSensorBase):
         super().__init__(
             coordinator=coordinator,
             config_entry=config_entry,
-            name=field,
             unique_id=f"{coordinator.unique_id}-{field}",
             icon="mdi:lightning-bolt",
         )
         self._attr_translation_key = "energy_history"
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        del self._attr_name
         self._attr_suggested_object_id = field
         self._attr_should_poll = False
         self._attr_state_class = SensorStateClass.TOTAL
@@ -1640,12 +1616,10 @@ class BoschComSensorEnergyHistoryHourly(BoschComSensorBase):
         super().__init__(
             coordinator=coordinator,
             config_entry=config_entry,
-            name=field,
             unique_id=f"{coordinator.unique_id}-{field}",
         )
         self._attr_translation_key = "energy_history_hourly"
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        del self._attr_name
         self._attr_suggested_object_id = field
         self._attr_should_poll = False
         self._attr_state_class = SensorStateClass.TOTAL
@@ -1806,7 +1780,6 @@ class BoschComThermostatHumiditySensor(_ThermostatDeviceSensorBase):
             icon="mdi:water-percent",
         )
         self._attr_translation_key = "thermostat_humidity"
-        del self._attr_name
         self._attr_suggested_object_id = f"{dev_id}_humidity"
         self._attr_device_class = SensorDeviceClass.HUMIDITY
         self._attr_native_unit_of_measurement = "%"
@@ -1837,7 +1810,6 @@ class BoschComThermostatSetpointSensor(_ThermostatDeviceSensorBase):
             icon="mdi:thermostat",
         )
         self._attr_translation_key = "thermostat_setpoint"
-        del self._attr_name
         self._attr_suggested_object_id = f"{dev_id}_setpoint"
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
@@ -1868,7 +1840,6 @@ class BoschComThermostatBatterySensor(_ThermostatDeviceSensorBase):
             icon="mdi:battery",
         )
         self._attr_translation_key = "thermostat_battery"
-        del self._attr_name
         self._attr_suggested_object_id = f"{dev_id}_battery"
         self._attr_device_class = SensorDeviceClass.BATTERY
         self._attr_native_unit_of_measurement = "%"
@@ -1899,7 +1870,6 @@ class BoschComThermostatSignalSensor(_ThermostatDeviceSensorBase):
             icon="mdi:signal",
         )
         self._attr_translation_key = "thermostat_signal"
-        del self._attr_name
         self._attr_suggested_object_id = f"{dev_id}_signal"
         self._attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
         self._attr_native_unit_of_measurement = "dBm"
@@ -1984,7 +1954,6 @@ class BoschComCommoduleStateSensor(_CommoduleSensorBase):
             coordinator, config_entry, cp_id, "wb_state", icon="mdi:ev-station"
         )
         self._attr_translation_key = "wb_state"
-        del self._attr_name
         self._attr_suggested_object_id = f"{cp_id}_state"
         self._attr_device_class = SensorDeviceClass.ENUM
         self._attr_options = self._WB_STATE_OPTIONS
@@ -2009,7 +1978,6 @@ class BoschComCommodulePowerSensor(_CommoduleSensorBase):
         """Initialize power sensor."""
         super().__init__(coordinator, config_entry, cp_id, "wb_power")
         self._attr_translation_key = "wb_power"
-        del self._attr_name
         self._attr_suggested_object_id = f"{cp_id}_power"
         self._attr_device_class = SensorDeviceClass.POWER
         self._attr_native_unit_of_measurement = "W"
@@ -2035,7 +2003,6 @@ class BoschComCommoduleEnergySensor(_CommoduleSensorBase):
         """Initialize energy sensor."""
         super().__init__(coordinator, config_entry, cp_id, "wb_energy_total")
         self._attr_translation_key = "wb_energy_total"
-        del self._attr_name
         self._attr_suggested_object_id = f"{cp_id}_energy_total"
         self._attr_device_class = SensorDeviceClass.ENERGY
         self._attr_native_unit_of_measurement = "kWh"
@@ -2061,7 +2028,6 @@ class BoschComCommoduleTempSensor(_CommoduleSensorBase):
         """Initialize temperature sensor."""
         super().__init__(coordinator, config_entry, cp_id, "wb_temperature")
         self._attr_translation_key = "wb_temperature"
-        del self._attr_name
         self._attr_suggested_object_id = f"{cp_id}_temperature"
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
@@ -2089,7 +2055,6 @@ class BoschComCommodulePhasesSensor(_CommoduleSensorBase):
             coordinator, config_entry, cp_id, "wb_phases", icon="mdi:sine-wave"
         )
         self._attr_translation_key = "wb_phases"
-        del self._attr_name
         self._attr_suggested_object_id = f"{cp_id}_phases"
 
     @property
@@ -2112,7 +2077,6 @@ class BoschComCommodulePhaseSensor(_CommoduleSensorBase):
             icon="mdi:sine-wave",
         )
         self._attr_translation_key = "wb_phase_sensor"
-        self._attr_name = f"{cp_id}_{phase_key}"
         self._phase_key = phase_key
 
     @property
@@ -2145,7 +2109,6 @@ class BoschComCommoduleChargelogSensor(_CommoduleSensorBase):
             coordinator, config_entry, cp_id, "wb_chargelog", icon="mdi:history"
         )
         self._attr_translation_key = "wb_chargelog"
-        del self._attr_name
         self._attr_suggested_object_id = f"{cp_id}_chargelog"
         self._attr_device_class = SensorDeviceClass.TIMESTAMP
 

--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -1750,7 +1750,7 @@ class BoschComThermostatRoomTempSensor(_ThermostatDeviceSensorBase):
             icon="mdi:thermometer",
         )
         self._attr_translation_key = "thermostat_room_temp"
-        self._suggested_object_id = f"{dev_id}_room_temp"
+        self._attr_suggested_object_id = f"{dev_id}_room_temp"
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_state_class = SensorStateClass.MEASUREMENT

--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -29,7 +29,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import BOSCH_SENSOR_DESCRIPTORS
+from .const import get_field_number, BOSCH_SENSOR_DESCRIPTORS
 from .coordinator import (
     BoschComModuleCoordinatorCommodule,
     BoschComModuleCoordinatorIcom,
@@ -538,7 +538,7 @@ class BoschComSensorDhw(BoschComSensorBase):
             icon="mdi:water-boiler",
         )
         self._attr_translation_key = "dhw"
-        self._attr_translation_placeholders = {"circuit": field}
+        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         del self._attr_name
         self._attr_should_poll = False
@@ -635,7 +635,7 @@ class BoschComSensorHc(BoschComSensorBase):
             icon="mdi:heating-coil",
         )
         self._attr_translation_key = "hc"
-        self._attr_translation_placeholders = {"circuit": field}
+        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         del self._attr_name
         self._attr_should_poll = False
@@ -757,7 +757,7 @@ class BoschComSensorVentilation(BoschComSensorBase):
             icon="mdi:fan",
         )
         self._attr_translation_key = "ventilation"
-        self._attr_translation_placeholders = {"zone": field}
+        self._attr_translation_placeholders = {"zone": get_field_number(field)}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         del self._attr_name
         self._attr_should_poll = False
@@ -1126,7 +1126,7 @@ class BoschComSensorDhwWddw2(BoschComSensorBase):
             icon="mdi:water-boiler",
         )
         self._attr_translation_key = "dhw"
-        self._attr_translation_placeholders = {"circuit": field}
+        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         del self._attr_name
         self._attr_should_poll = False

--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -430,6 +430,7 @@ class BoschComSensorNotificationsRac(BoschComSensorBase):
 
         _LOGGER.debug(
             "Init BoschComSensorNotificationsRac: unique_id=%s",
+            self._attr_suggested_object_id = "notifications"
             self._attr_unique_id,
         )
 
@@ -464,6 +465,7 @@ class BoschComSensorNotificationsK40(BoschComSensorBase):
 
         _LOGGER.debug(
             "Init BoschComSensorNotificationsK40: unique_id=%s",
+            self._attr_suggested_object_id = "notifications"
             self._attr_unique_id,
         )
 
@@ -502,6 +504,7 @@ class BoschComSensorNotificationsWddw2(BoschComSensorBase):
 
         _LOGGER.debug(
             "Init BoschComSensorNotificationsWddw2: unique_id=%s",
+            self._attr_suggested_object_id = "notifications"
             self._attr_unique_id,
         )
 
@@ -540,6 +543,7 @@ class BoschComSensorDhw(BoschComSensorBase):
         del self._attr_name
         self._attr_should_poll = False
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
+        self._attr_suggested_object_id = field + "_sensor"
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self.field = field
@@ -636,6 +640,7 @@ class BoschComSensorHc(BoschComSensorBase):
         del self._attr_name
         self._attr_should_poll = False
         self._attr_device_class = SensorDeviceClass.ENUM
+            self._attr_suggested_object_id = f"{field}_sensor"
         self._attr_options = ["off", "manual", "auto"]
         self.field = field
 
@@ -757,6 +762,7 @@ class BoschComSensorVentilation(BoschComSensorBase):
         del self._attr_name
         self._attr_should_poll = False
         self._attr_device_class = SensorDeviceClass.ENUM
+            self._attr_suggested_object_id = field + "_sensor"
         self._attr_options = ["off", "min", "red", "nom", "max", "dem"]
         self.field = field
 

--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -629,9 +629,9 @@ class BoschComSensorHc(BoschComSensorBase):
         self._attr_translation_key = "hc"
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
+        self._attr_suggested_object_id = field + "_sensor"
         self._attr_should_poll = False
         self._attr_device_class = SensorDeviceClass.ENUM
-        self._attr_suggested_object_id = f"{field}_sensor"
         self._attr_options = ["off", "manual", "auto"]
         self.field = field
 
@@ -749,9 +749,9 @@ class BoschComSensorVentilation(BoschComSensorBase):
         self._attr_translation_key = "ventilation"
         self._attr_translation_placeholders = {"zone": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
+        self._attr_suggested_object_id = field + "_sensor"
         self._attr_should_poll = False
         self._attr_device_class = SensorDeviceClass.ENUM
-        self._attr_suggested_object_id = field + "_sensor"
         self._attr_options = ["off", "min", "red", "nom", "max", "dem"]
         self.field = field
 
@@ -2077,6 +2077,7 @@ class BoschComCommodulePhaseSensor(_CommoduleSensorBase):
             icon="mdi:sine-wave",
         )
         self._attr_translation_key = "wb_phase_sensor"
+        self._attr_suggested_object_id = f"{cp_id}_{phase_key}"
         self._phase_key = phase_key
 
     @property

--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -425,7 +425,7 @@ class BoschComSensorNotificationsRac(BoschComSensorBase):
         )
         self._attr_translation_key = "notifications"
         self._attr_unique_id = f"{coordinator.unique_id}-notifications"
-        self._attr_name = "notifications"
+        self._attr_name = None
         self._attr_should_poll = False
 
         _LOGGER.debug(
@@ -460,7 +460,7 @@ class BoschComSensorNotificationsK40(BoschComSensorBase):
         )
         self._attr_translation_key = "notifications"
         self._attr_unique_id = f"{coordinator.unique_id}-notifications"
-        self._attr_name = "notifications"
+        self._attr_name = None
         self._attr_should_poll = False
 
         _LOGGER.debug(
@@ -499,7 +499,7 @@ class BoschComSensorNotificationsWddw2(BoschComSensorBase):
         )
         self._attr_translation_key = "notifications"
         self._attr_unique_id = f"{coordinator.unique_id}-notifications"
-        self._attr_name = "notifications"
+        self._attr_name = None
         self._attr_should_poll = False
 
         _LOGGER.debug(
@@ -540,7 +540,7 @@ class BoschComSensorDhw(BoschComSensorBase):
         self._attr_translation_key = "dhw"
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field + "_sensor"
+        self._attr_name = None
         self._attr_should_poll = False
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
@@ -636,7 +636,7 @@ class BoschComSensorHc(BoschComSensorBase):
         self._attr_translation_key = "hc"
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field + "_sensor"
+        self._attr_name = None
         self._attr_should_poll = False
         self._attr_device_class = SensorDeviceClass.ENUM
         self._attr_options = ["off", "manual", "auto"]
@@ -757,7 +757,7 @@ class BoschComSensorVentilation(BoschComSensorBase):
         self._attr_translation_key = "ventilation"
         self._attr_translation_placeholders = {"zone": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field + "_sensor"
+        self._attr_name = None
         self._attr_should_poll = False
         self._attr_device_class = SensorDeviceClass.ENUM
         self._attr_options = ["off", "min", "red", "nom", "max", "dem"]
@@ -1125,7 +1125,7 @@ class BoschComSensorDhwWddw2(BoschComSensorBase):
         self._attr_translation_key = "dhw"
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_name = field + "_sensor"
+        self._attr_name = None
         self._attr_should_poll = False
         self.field = field
 

--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -425,12 +425,12 @@ class BoschComSensorNotificationsRac(BoschComSensorBase):
         )
         self._attr_translation_key = "notifications"
         self._attr_unique_id = f"{coordinator.unique_id}-notifications"
+        self._attr_suggested_object_id = "notifications"
         del self._attr_name
         self._attr_should_poll = False
 
         _LOGGER.debug(
             "Init BoschComSensorNotificationsRac: unique_id=%s",
-            self._attr_suggested_object_id = "notifications"
             self._attr_unique_id,
         )
 
@@ -460,12 +460,12 @@ class BoschComSensorNotificationsK40(BoschComSensorBase):
         )
         self._attr_translation_key = "notifications"
         self._attr_unique_id = f"{coordinator.unique_id}-notifications"
+        self._attr_suggested_object_id = "notifications"
         del self._attr_name
         self._attr_should_poll = False
 
         _LOGGER.debug(
             "Init BoschComSensorNotificationsK40: unique_id=%s",
-            self._attr_suggested_object_id = "notifications"
             self._attr_unique_id,
         )
 
@@ -499,12 +499,12 @@ class BoschComSensorNotificationsWddw2(BoschComSensorBase):
         )
         self._attr_translation_key = "notifications"
         self._attr_unique_id = f"{coordinator.unique_id}-notifications"
+        self._attr_suggested_object_id = "notifications"
         del self._attr_name
         self._attr_should_poll = False
 
         _LOGGER.debug(
             "Init BoschComSensorNotificationsWddw2: unique_id=%s",
-            self._attr_suggested_object_id = "notifications"
             self._attr_unique_id,
         )
 
@@ -640,7 +640,7 @@ class BoschComSensorHc(BoschComSensorBase):
         del self._attr_name
         self._attr_should_poll = False
         self._attr_device_class = SensorDeviceClass.ENUM
-            self._attr_suggested_object_id = f"{field}_sensor"
+        self._attr_suggested_object_id = f"{field}_sensor"
         self._attr_options = ["off", "manual", "auto"]
         self.field = field
 
@@ -762,7 +762,7 @@ class BoschComSensorVentilation(BoschComSensorBase):
         del self._attr_name
         self._attr_should_poll = False
         self._attr_device_class = SensorDeviceClass.ENUM
-            self._attr_suggested_object_id = field + "_sensor"
+        self._attr_suggested_object_id = field + "_sensor"
         self._attr_options = ["off", "min", "red", "nom", "max", "dem"]
         self.field = field
 

--- a/custom_components/bosch_homecom/strings.json
+++ b/custom_components/bosch_homecom/strings.json
@@ -1,371 +1,371 @@
 {
-    "config": {
-        "step": {
-            "user": {
-                "data": {
-                    "username": "SingleKey ID username",
-                    "password": "SingleKey ID password",
-                    "brand_buderus": "Buderus brand"
-                },
-                "description": "Enter your SingleKey ID Credentials",
-                "title": "Authentication"
-            },
-            "reauth_confirm": {
-                "description": "Please enter the correct username and password for SingleKey ID",
-                "data": {
-                    "username": "SingleKey ID username",
-                    "password": "SingleKey ID password"
-                }
-            },
-            "reconfigure": {
-                "description": "Update configuration for SingleKey ID.",
-                "data": {
-                    "username": "SingleKey ID username",
-                    "password": "SingleKey ID password"
-                },
-                "title": "Authentication"
-            },
-            "browser": {
-                "description": "Login in browser using [URL]({url}) in readme and capture code using browser's developer tools.",
-                "data": {
-                    "code": "SingleKey ID code"
-                },
-                "title": "Browser Authentication"
-            }
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "username": "SingleKey ID username",
+          "password": "SingleKey ID password",
+          "brand_buderus": "Buderus brand"
         },
-        "error": {
-            "username_required": "Username is required.",
-            "code_required": "Verification code is required.",
-            "unknown": "An unknown error occurred.",
-            "cannot_connect": "Cannot connect to Bosch servers.",
-            "no_devices_found": "No devices found.",
-            "no_device_selected": "You must select at least one device.",
-            "already_configured": "This account is already configured."
-        },
-        "abort": {
-            "already_configured": "Already configured",
-            "device_unsupported": "The device is unsupported.",
-            "reauth_successful": "Reauth successful",
-            "reauth_unsuccessful": "Re-authentication was unsuccessful, please remove the integration and set it up again.",
-            "reconfigure_successful": "Reconfigure successful"
+        "description": "Enter your SingleKey ID Credentials",
+        "title": "Authentication"
+      },
+      "reauth_confirm": {
+        "description": "Please enter the correct username and password for SingleKey ID",
+        "data": {
+          "username": "SingleKey ID username",
+          "password": "SingleKey ID password"
         }
+      },
+      "reconfigure": {
+        "description": "Update configuration for SingleKey ID.",
+        "data": {
+          "username": "SingleKey ID username",
+          "password": "SingleKey ID password"
+        },
+        "title": "Authentication"
+      },
+      "browser": {
+        "description": "Login in browser using [URL]({url}) in readme and capture code using browser's developer tools.",
+        "data": {
+          "code": "SingleKey ID code"
+        },
+        "title": "Browser Authentication"
+      }
     },
-    "options": {
-        "step": {
-            "init": {
-                "title": "Options",
-                "description": "Adjust runtime options for Bosch HomeCom.",
-                "data": {
-                    "update_seconds": "Update interval (seconds)",
-                    "brand_buderus": "Buderus brand",
-                    "wb_label": "Wallbox label"
-                }
-            }
-        }
+    "error": {
+      "username_required": "Username is required.",
+      "code_required": "Verification code is required.",
+      "unknown": "An unknown error occurred.",
+      "cannot_connect": "Cannot connect to Bosch servers.",
+      "no_devices_found": "No devices found.",
+      "no_device_selected": "You must select at least one device.",
+      "already_configured": "This account is already configured."
     },
-    "entity": {
-        "climate": {
-            "zone": {
-                "name": "Zone"
-            },
-            "ac": {
-                "name": "Air conditioner"
-            },
-            "hc": {
-                "name": "Heating circuit {circuit}"
-            }
-        },
-        "fan": {
-            "ventilation": {
-                "name": "Ventilation {zone}",
-                "state_attributes": {
-                    "preset_mode": {
-                        "state": {
-                            "off": "Off",
-                            "min": "Level 1 (Minimum)",
-                            "red": "Level 2 (Reduced)",
-                            "nom": "Level 3 (Normal)",
-                            "max": "Level 4 (Maximum)",
-                            "dem": "Demand-based",
-                            "time": "Time-based",
-                            "party": "Party",
-                            "fireplace": "Fireplace"
-                        }
-                    }
-                }
-            }
-        },
-        "select": {
-            "airflow_horizontal": {
-                "name": "Horizontal airflow",
-                "state": {
-                    "center": "Center",
-                    "left": "Left",
-                    "right": "Right",
-                    "swing": "Swing"
-                }
-            },
-            "airflow_vertical": {
-                "name": "Vertical airflow",
-                "state": {
-                    "auto": "Auto",
-                    "angle1": "Angle 1",
-                    "angle2": "Angle 2",
-                    "angle3": "Angle 3",
-                    "angle4": "Angle 4",
-                    "angle5": "Angle 5",
-                    "swing": "Swing"
-                }
-            },
-            "program": {
-                "name": "Program",
-                "state": {
-                    "off": "Off",
-                    "program1": "Program 1",
-                    "program2": "Program 2"
-                }
-            },
-            "dhw_operation_mode": {
-                "name": "{circuit} operation mode",
-                "state": {
-                    "off": "Off",
-                    "low": "Low (Eco)",
-                    "high": "High (Comfort)",
-                    "eco": "Eco+",
-                    "ownprogram": "Own program",
-                    "manual": "Manual"
-                }
-            },
-            "dhw_current_temp": {
-                "name": "{circuit} temperature level",
-                "state": {
-                    "off": "Off",
-                    "low": "Low",
-                    "high": "High",
-                    "eco": "Eco"
-                }
-            },
-            "hc_operation_mode": {
-                "name": "{circuit} operation mode",
-                "state": {
-                    "off": "Off",
-                    "manual": "Manual",
-                    "auto": "Auto"
-                }
-            },
-            "hc_suwi_mode": {
-                "name": "{circuit} summer/winter mode",
-                "state": {
-                    "forced": "Forced",
-                    "off": "Off",
-                    "cooling": "Cooling"
-                }
-            },
-            "hc_heatcool_mode": {
-                "name": "{circuit} heat/cool mode",
-                "state": {
-                    "heat": "Heat",
-                    "cool": "Cool"
-                }
-            },
-            "holiday_mode": {
-                "name": "Holiday mode",
-                "state": {
-                    "hm1": "Holiday mode 1",
-                    "hm2": "Holiday mode 2",
-                    "hm3": "Holiday mode 3",
-                    "hm4": "Holiday mode 4",
-                    "hm5": "Holiday mode 5",
-                    "hm6": "Holiday mode 6",
-                    "hm7": "Holiday mode 7",
-                    "hm8": "Holiday mode 8"
-                }
-            },
-            "away_mode": {
-                "name": "Away mode",
-                "state": {
-                    "on": "On",
-                    "off": "Off"
-                }
-            },
-            "hc_night_switch_mode": {
-                "name": "HC Night Switch Mode"
-            },
-            "hc_control": {
-                "name": "HC Control"
-            },
-            "ventilation_summer_enable": {
-                "name": "Summer bypass",
-                "state": {
-                    "no": "Off",
-                    "yes": "On"
-                }
-            },
-            "wb_charging_strategy": {
-                "name": "Charging Strategy",
-                "state": {
-                    "default": "Default",
-                    "solar-eco": "Solar Eco"
-                }
-            }
-        },
-        "sensor": {
-            "hc": {
-                "name": "{circuit} status",
-                "state": {
-                    "off": "Off",
-                    "manual": "Manual",
-                    "auto": "Auto"
-                }
-            },
-            "indoor_humidity": {
-                "name": "Indoor Humidity"
-            },
-            "flame_indication": {
-                "name": "Flame Indication"
-            },
-            "energy_history": {
-                "name": "Energy History"
-            },
-            "ventilation": {
-                "name": "{zone} level",
-                "state": {
-                    "off": "Off",
-                    "min": "Level 1 (Minimum)",
-                    "red": "Level 2 (Reduced)",
-                    "nom": "Level 3 (Normal)",
-                    "max": "Level 4 (Maximum)",
-                    "dem": "Demand-based"
-                }
-            },
-            "wb_state": {
-                "name": "Wallbox State",
-                "state": {
-                    "available": "Available",
-                    "authenticated": "Authenticated",
-                    "preparing": "Awaiting Authorization",
-                    "locked": "Locked",
-                    "charging": "Charging",
-                    "suspendedev": "Vehicle Paused",
-                    "suspendedevse": "Wallbox Paused",
-                    "init": "Initializing",
-                    "faulted": "Faulted",
-                    "limited": "Power Limited",
-                    "phaseswitch": "Phase Switching"
-                }
-            },
-            "wb_power": {
-                "name": "Wallbox Power"
-            },
-            "wb_energy_total": {
-                "name": "Wallbox Energy Total"
-            },
-            "wb_temperature": {
-                "name": "Wallbox Temperature"
-            },
-            "wb_phases": {
-                "name": "Wallbox Phases"
-            },
-            "wb_phase_sensor": {
-                "name": "Wallbox Phase"
-            },
-            "wb_chargelog": {
-                "name": "Wallbox Charge Log"
-            },
-            "thermostat_room_temp": {
-                "name": "Room Temperature"
-            },
-            "thermostat_humidity": {
-                "name": "Room Humidity"
-            },
-            "thermostat_setpoint": {
-                "name": "Room Setpoint"
-            },
-            "thermostat_battery": {
-                "name": "Battery"
-            },
-            "thermostat_signal": {
-                "name": "Signal Strength"
-            },
-            "dhw": {
-                "name": "{circuit} temperature"
-            },
-            "hs": {
-                "name": "Heat source"
-            },
-            "outdoor_temp": {
-                "name": "Outdoor temperature"
-            },
-            "notifications": {
-                "name": "Notifications"
-            },
-            "energy_history_hourly": {
-                "name": "Energy history (hourly)"
-            }
-        },
-        "binary_sensor": {
-            "wb_network": {
-                "name": "Wallbox Network"
-            },
-            "thermostat_rf_status": {
-                "name": "RF Connection"
-            }
-        },
-        "number": {
-            "wb_price": {
-                "name": "Electricity Price"
-            },
-            "wb_charge_limit": {
-                "name": "Charging Limit"
-            },
-            "ventilation_summer_duration": {
-                "name": "Summer bypass duration"
-            }
-        },
-        "button": {
-            "wb_authenticate": {
-                "name": "Authenticate Charging"
-            },
-            "wb_start_charging": {
-                "name": "Start Charging"
-            },
-            "wb_pause_charging": {
-                "name": "Pause Charging"
-            }
-        },
-        "switch": {
-            "child_lock": {
-                "name": "Child Lock"
-            },
-            "wb_locked": {
-                "name": "Wallbox Locked"
-            },
-            "wb_auth": {
-                "name": "Wallbox Auth"
-            },
-            "wb_rfid_secure": {
-                "name": "Wallbox RFID Secure"
-            },
-            "plasmacluster": {
-                "name": "Plasmacluster"
-            }
-        },
-        "water_heater": {
-            "dhw": {
-                "name": "Water heater {circuit}",
-                "state_attributes": {
-                    "operation_mode": {
-                        "state": {
-                            "off": "Off",
-                            "low": "Low (Eco)",
-                            "high": "High (Comfort)",
-                            "eco": "Eco+",
-                            "manual": "Manual",
-                            "ownprogram": "Own program"
-                        }
-                    }
-                }
-            }
-        }
+    "abort": {
+      "already_configured": "Already configured",
+      "device_unsupported": "The device is unsupported.",
+      "reauth_successful": "Reauth successful",
+      "reauth_unsuccessful": "Re-authentication was unsuccessful, please remove the integration and set it up again.",
+      "reconfigure_successful": "Reconfigure successful"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options",
+        "description": "Adjust runtime options for Bosch HomeCom.",
+        "data": {
+          "update_seconds": "Update interval (seconds)",
+          "brand_buderus": "Buderus brand",
+          "wb_label": "Wallbox label"
+        }
+      }
+    }
+  },
+  "entity": {
+    "climate": {
+      "zone": {
+        "name": "Zone {zone}"
+      },
+      "ac": {
+        "name": "Air conditioner"
+      },
+      "hc": {
+        "name": "Heating circuit {circuit}"
+      }
+    },
+    "fan": {
+      "ventilation": {
+        "name": "Ventilation {zone}",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "off": "Off",
+              "min": "Level 1 (Minimum)",
+              "red": "Level 2 (Reduced)",
+              "nom": "Level 3 (Normal)",
+              "max": "Level 4 (Maximum)",
+              "dem": "Demand-based",
+              "time": "Time-based",
+              "party": "Party",
+              "fireplace": "Fireplace"
+            }
+          }
+        }
+      }
+    },
+    "select": {
+      "airflow_horizontal": {
+        "name": "Horizontal airflow",
+        "state": {
+          "center": "Center",
+          "left": "Left",
+          "right": "Right",
+          "swing": "Swing"
+        }
+      },
+      "airflow_vertical": {
+        "name": "Vertical airflow",
+        "state": {
+          "auto": "Auto",
+          "angle1": "Angle 1",
+          "angle2": "Angle 2",
+          "angle3": "Angle 3",
+          "angle4": "Angle 4",
+          "angle5": "Angle 5",
+          "swing": "Swing"
+        }
+      },
+      "program": {
+        "name": "Program",
+        "state": {
+          "off": "Off",
+          "program1": "Program 1",
+          "program2": "Program 2"
+        }
+      },
+      "dhw_operation_mode": {
+        "name": "{circuit} operation mode",
+        "state": {
+          "off": "Off",
+          "low": "Low (Eco)",
+          "high": "High (Comfort)",
+          "eco": "Eco+",
+          "ownprogram": "Own program",
+          "manual": "Manual"
+        }
+      },
+      "dhw_current_temp": {
+        "name": "{circuit} temperature level",
+        "state": {
+          "off": "Off",
+          "low": "Low",
+          "high": "High",
+          "eco": "Eco"
+        }
+      },
+      "hc_operation_mode": {
+        "name": "{circuit} operation mode",
+        "state": {
+          "off": "Off",
+          "manual": "Manual",
+          "auto": "Auto"
+        }
+      },
+      "hc_suwi_mode": {
+        "name": "{circuit} summer/winter mode",
+        "state": {
+          "forced": "Forced",
+          "off": "Off",
+          "cooling": "Cooling"
+        }
+      },
+      "hc_heatcool_mode": {
+        "name": "{circuit} heat/cool mode",
+        "state": {
+          "heat": "Heat",
+          "cool": "Cool"
+        }
+      },
+      "holiday_mode": {
+        "name": "Holiday mode",
+        "state": {
+          "hm1": "Holiday mode 1",
+          "hm2": "Holiday mode 2",
+          "hm3": "Holiday mode 3",
+          "hm4": "Holiday mode 4",
+          "hm5": "Holiday mode 5",
+          "hm6": "Holiday mode 6",
+          "hm7": "Holiday mode 7",
+          "hm8": "Holiday mode 8"
+        }
+      },
+      "away_mode": {
+        "name": "Away mode",
+        "state": {
+          "on": "On",
+          "off": "Off"
+        }
+      },
+      "hc_night_switch_mode": {
+        "name": "{circuit} night switch mode"
+      },
+      "hc_control": {
+        "name": "{circuit} control"
+      },
+      "ventilation_summer_enable": {
+        "name": "{zone} summer bypass",
+        "state": {
+          "no": "Off",
+          "yes": "On"
+        }
+      },
+      "wb_charging_strategy": {
+        "name": "Charging Strategy",
+        "state": {
+          "default": "Default",
+          "solar-eco": "Solar Eco"
+        }
+      }
+    },
+    "sensor": {
+      "hc": {
+        "name": "{circuit} status",
+        "state": {
+          "off": "Off",
+          "manual": "Manual",
+          "auto": "Auto"
+        }
+      },
+      "indoor_humidity": {
+        "name": "Indoor Humidity"
+      },
+      "flame_indication": {
+        "name": "Flame Indication"
+      },
+      "energy_history": {
+        "name": "Energy History"
+      },
+      "ventilation": {
+        "name": "{zone} level",
+        "state": {
+          "off": "Off",
+          "min": "Level 1 (Minimum)",
+          "red": "Level 2 (Reduced)",
+          "nom": "Level 3 (Normal)",
+          "max": "Level 4 (Maximum)",
+          "dem": "Demand-based"
+        }
+      },
+      "wb_state": {
+        "name": "Wallbox State",
+        "state": {
+          "available": "Available",
+          "authenticated": "Authenticated",
+          "preparing": "Awaiting Authorization",
+          "locked": "Locked",
+          "charging": "Charging",
+          "suspendedev": "Vehicle Paused",
+          "suspendedevse": "Wallbox Paused",
+          "init": "Initializing",
+          "faulted": "Faulted",
+          "limited": "Power Limited",
+          "phaseswitch": "Phase Switching"
+        }
+      },
+      "wb_power": {
+        "name": "Wallbox Power"
+      },
+      "wb_energy_total": {
+        "name": "Wallbox Energy Total"
+      },
+      "wb_temperature": {
+        "name": "Wallbox Temperature"
+      },
+      "wb_phases": {
+        "name": "Wallbox Phases"
+      },
+      "wb_phase_sensor": {
+        "name": "Wallbox Phase"
+      },
+      "wb_chargelog": {
+        "name": "Wallbox Charge Log"
+      },
+      "thermostat_room_temp": {
+        "name": "Room Temperature"
+      },
+      "thermostat_humidity": {
+        "name": "Room Humidity"
+      },
+      "thermostat_setpoint": {
+        "name": "Room Setpoint"
+      },
+      "thermostat_battery": {
+        "name": "Battery"
+      },
+      "thermostat_signal": {
+        "name": "Signal Strength"
+      },
+      "dhw": {
+        "name": "{circuit} temperature"
+      },
+      "hs": {
+        "name": "Heat source"
+      },
+      "outdoor_temp": {
+        "name": "Outdoor temperature"
+      },
+      "notifications": {
+        "name": "Notifications"
+      },
+      "energy_history_hourly": {
+        "name": "Energy history (hourly)"
+      }
+    },
+    "binary_sensor": {
+      "wb_network": {
+        "name": "Wallbox Network"
+      },
+      "thermostat_rf_status": {
+        "name": "RF Connection"
+      }
+    },
+    "number": {
+      "wb_price": {
+        "name": "Electricity Price"
+      },
+      "wb_charge_limit": {
+        "name": "Charging Limit"
+      },
+      "ventilation_summer_duration": {
+        "name": "Summer bypass duration"
+      }
+    },
+    "button": {
+      "wb_authenticate": {
+        "name": "Authenticate Charging"
+      },
+      "wb_start_charging": {
+        "name": "Start Charging"
+      },
+      "wb_pause_charging": {
+        "name": "Pause Charging"
+      }
+    },
+    "switch": {
+      "child_lock": {
+        "name": "Child Lock"
+      },
+      "wb_locked": {
+        "name": "Wallbox Locked"
+      },
+      "wb_auth": {
+        "name": "Wallbox Auth"
+      },
+      "wb_rfid_secure": {
+        "name": "Wallbox RFID Secure"
+      },
+      "plasmacluster": {
+        "name": "Plasmacluster"
+      }
+    },
+    "water_heater": {
+      "dhw": {
+        "name": "Water heater {circuit}",
+        "state_attributes": {
+          "operation_mode": {
+            "state": {
+              "off": "Off",
+              "low": "Low (Eco)",
+              "high": "High (Comfort)",
+              "eco": "Eco+",
+              "manual": "Manual",
+              "ownprogram": "Own program"
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/custom_components/bosch_homecom/strings.json
+++ b/custom_components/bosch_homecom/strings.json
@@ -352,7 +352,7 @@
     },
     "water_heater": {
       "dhw": {
-        "name": "Water heater {circuit}",
+        "name": "Water heater",
         "state_attributes": {
           "operation_mode": {
             "state": {

--- a/custom_components/bosch_homecom/strings.json
+++ b/custom_components/bosch_homecom/strings.json
@@ -352,7 +352,7 @@
     },
     "water_heater": {
       "dhw": {
-        "name": "Water heater",
+        "name": "Water heater {circuit}",
         "state_attributes": {
           "operation_mode": {
             "state": {

--- a/custom_components/bosch_homecom/strings.json
+++ b/custom_components/bosch_homecom/strings.json
@@ -319,7 +319,7 @@
         "name": "Charging Limit"
       },
       "ventilation_summer_duration": {
-        "name": "Summer bypass duration"
+        "name": "{zone} summer bypass duration"
       }
     },
     "button": {

--- a/custom_components/bosch_homecom/translations/de.json
+++ b/custom_components/bosch_homecom/translations/de.json
@@ -320,7 +320,7 @@
         "name": "Ladestromlimit"
       },
       "ventilation_summer_duration": {
-        "name": "Sommer-Bypass Dauer"
+        "name": "{zone} Sommer-Bypass Dauer"
       }
     },
     "button": {

--- a/custom_components/bosch_homecom/translations/de.json
+++ b/custom_components/bosch_homecom/translations/de.json
@@ -353,7 +353,7 @@
     },
     "water_heater": {
       "dhw": {
-        "name": "Warmwasser {circuit}",
+        "name": "Warmwasser",
         "state_attributes": {
           "operation_mode": {
             "state": {

--- a/custom_components/bosch_homecom/translations/de.json
+++ b/custom_components/bosch_homecom/translations/de.json
@@ -353,7 +353,7 @@
     },
     "water_heater": {
       "dhw": {
-        "name": "Warmwasser",
+        "name": "Warmwasser {circuit}",
         "state_attributes": {
           "operation_mode": {
             "state": {

--- a/custom_components/bosch_homecom/translations/de.json
+++ b/custom_components/bosch_homecom/translations/de.json
@@ -1,372 +1,372 @@
 {
-    "config": {
-        "step": {
-            "user": {
-                "data": {
-                    "username": "SingleKey ID Benutzername",
-                    "password": "SingleKey ID Passwort"
-                },
-                "description": "Geben Sie Ihre SingleKey ID Anmeldedaten ein",
-                "title": "Authentifizierung"
-            },
-            "reauth_confirm": {
-                "description": "Bitte geben Sie den korrekten Benutzernamen und das Passwort für SingleKey ID ein",
-                "data": {
-                    "username": "SingleKey ID Benutzername",
-                    "password": "SingleKey ID Passwort"
-                }
-            },
-            "reconfigure": {
-                "description": "Konfiguration für SingleKey ID aktualisieren.",
-                "data": {
-                    "username": "SingleKey ID Benutzername",
-                    "password": "SingleKey ID Passwort"
-                },
-                "title": "Authentifizierung"
-            },
-            "browser": {
-                "description": "Melden Sie sich im Browser über die [URL]({url}) in der Readme an und erfassen Sie den Code mit den Entwicklertools des Browsers.",
-                "data": {
-                    "code": "SingleKey ID Code"
-                },
-                "title": "Browser-Authentifizierung"
-            }
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "username": "SingleKey ID Benutzername",
+          "password": "SingleKey ID Passwort"
         },
-        "error": {
-            "username_required": "Benutzername ist erforderlich.",
-            "code_required": "Verifizierungscode ist erforderlich.",
-            "unknown": "Ein unbekannter Fehler ist aufgetreten.",
-            "cannot_connect": "Verbindung zu Bosch-Servern nicht möglich.",
-            "no_devices_found": "Keine Geräte gefunden.",
-            "no_device_selected": "Sie müssen mindestens ein Gerät auswählen.",
-            "already_configured": "Dieses Konto ist bereits konfiguriert."
-        },
-        "abort": {
-            "already_configured": "Bereits konfiguriert",
-            "device_unsupported": "Das Gerät wird nicht unterstützt.",
-            "reauth_successful": "Erneute Authentifizierung erfolgreich",
-            "reauth_unsuccessful": "Die erneute Authentifizierung war nicht erfolgreich. Bitte entfernen Sie die Integration und richten Sie sie erneut ein.",
-            "reconfigure_successful": "Neukonfiguration erfolgreich"
+        "description": "Geben Sie Ihre SingleKey ID Anmeldedaten ein",
+        "title": "Authentifizierung"
+      },
+      "reauth_confirm": {
+        "description": "Bitte geben Sie den korrekten Benutzernamen und das Passwort für SingleKey ID ein",
+        "data": {
+          "username": "SingleKey ID Benutzername",
+          "password": "SingleKey ID Passwort"
         }
+      },
+      "reconfigure": {
+        "description": "Konfiguration für SingleKey ID aktualisieren.",
+        "data": {
+          "username": "SingleKey ID Benutzername",
+          "password": "SingleKey ID Passwort"
+        },
+        "title": "Authentifizierung"
+      },
+      "browser": {
+        "description": "Melden Sie sich im Browser über die [URL]({url}) in der Readme an und erfassen Sie den Code mit den Entwicklertools des Browsers.",
+        "data": {
+          "code": "SingleKey ID Code"
+        },
+        "title": "Browser-Authentifizierung"
+      }
     },
-    "options": {
-        "step": {
-            "init": {
-                "title": "Optionen",
-                "description": "Laufzeitoptionen für Bosch HomeCom anpassen.",
-                "data": {
-                    "update_seconds": "Aktualisierungsintervall (Sekunden)",
-                    "brand_buderus": "Buderus Marke",
-                    "wb_label": "Wallbox Bezeichnung"
-                }
-            }
-        }
+    "error": {
+      "username_required": "Benutzername ist erforderlich.",
+      "code_required": "Verifizierungscode ist erforderlich.",
+      "unknown": "Ein unbekannter Fehler ist aufgetreten.",
+      "cannot_connect": "Verbindung zu Bosch-Servern nicht möglich.",
+      "no_devices_found": "Keine Geräte gefunden.",
+      "no_device_selected": "Sie müssen mindestens ein Gerät auswählen.",
+      "already_configured": "Dieses Konto ist bereits konfiguriert."
     },
-    "entity": {
-        "climate": {
-            "zone": {
-                "name": "Zone"
-            },
-            "ac": {
-                "name": "Klimaanlage"
-            },
-            "hc": {
-                "name": "Heizkreis {circuit}"
-            }
-        },
-        "fan": {
-            "ventilation": {
-                "name": "Lüftung {zone}",
-                "state_attributes": {
-                    "preset_mode": {
-                        "state": {
-                            "off": "Aus",
-                            "min": "Stufe 1 (Minimum)",
-                            "red": "Stufe 2 (Reduziert)",
-                            "nom": "Stufe 3 (Normal)",
-                            "max": "Stufe 4 (Maximum)",
-                            "dem": "Bedarfsgeregelt",
-                            "powerVent": "Intensivlüftung",
-                            "fallAsleep": "Schlafen",
-                            "time": "Auto",
-                            "party": "Party",
-                            "fireplace": "Kamin"
-                        }
-                    }
-                }
-            }
-        },
-        "select": {
-            "airflow_horizontal": {
-                "name": "Luftstrom horizontal",
-                "state": {
-                    "center": "Mitte",
-                    "left": "Links",
-                    "right": "Rechts",
-                    "swing": "Schwenken"
-                }
-            },
-            "airflow_vertical": {
-                "name": "Luftstrom vertikal",
-                "state": {
-                    "auto": "Automatisch",
-                    "angle1": "Winkel 1",
-                    "angle2": "Winkel 2",
-                    "angle3": "Winkel 3",
-                    "angle4": "Winkel 4",
-                    "angle5": "Winkel 5",
-                    "swing": "Schwenken"
-                }
-            },
-            "program": {
-                "name": "Programm",
-                "state": {
-                    "off": "Aus",
-                    "program1": "Programm 1",
-                    "program2": "Programm 2"
-                }
-            },
-            "dhw_operation_mode": {
-                "name": "{circuit} Betriebsmodus",
-                "state": {
-                    "off": "Aus",
-                    "low": "Niedrig (Eco)",
-                    "high": "Hoch (Komfort)",
-                    "eco": "Eco+",
-                    "ownprogram": "Eigenes Programm",
-                    "manual": "Manuell"
-                }
-            },
-            "dhw_current_temp": {
-                "name": "{circuit} Temperaturstufe",
-                "state": {
-                    "off": "Aus",
-                    "low": "Niedrig",
-                    "high": "Hoch",
-                    "eco": "Eco"
-                }
-            },
-            "hc_operation_mode": {
-                "name": "{circuit} Betriebsmodus",
-                "state": {
-                    "off": "Aus",
-                    "manual": "Manuell",
-                    "auto": "Automatisch"
-                }
-            },
-            "hc_suwi_mode": {
-                "name": "{circuit} Sommer/Winter",
-                "state": {
-                    "forced": "Erzwungen",
-                    "off": "Aus",
-                    "cooling": "Kühlung"
-                }
-            },
-            "hc_heatcool_mode": {
-                "name": "{circuit} Heizen/Kühlen",
-                "state": {
-                    "heat": "Heizen",
-                    "cool": "Kühlen"
-                }
-            },
-            "holiday_mode": {
-                "name": "Urlaubsmodus",
-                "state": {
-                    "hm1": "Urlaubsmodus 1",
-                    "hm2": "Urlaubsmodus 2",
-                    "hm3": "Urlaubsmodus 3",
-                    "hm4": "Urlaubsmodus 4",
-                    "hm5": "Urlaubsmodus 5",
-                    "hm6": "Urlaubsmodus 6",
-                    "hm7": "Urlaubsmodus 7",
-                    "hm8": "Urlaubsmodus 8"
-                }
-            },
-            "away_mode": {
-                "name": "Abwesenheit",
-                "state": {
-                    "on": "An",
-                    "off": "Aus"
-                }
-            },
-            "hc_night_switch_mode": {
-                "name": "HK Nachtabschaltung"
-            },
-            "hc_control": {
-                "name": "HK Regelung"
-            },
-            "ventilation_summer_enable": {
-                "name": "Sommer-Bypass",
-                "state": {
-                    "no": "Aus",
-                    "yes": "An"
-                }
-            },
-            "wb_charging_strategy": {
-                "name": "Ladestrategie",
-                "state": {
-                    "default": "Standard",
-                    "solar-eco": "Solar-Eco"
-                }
-            }
-        },
-        "sensor": {
-            "hc": {
-                "name": "{circuit} Status",
-                "state": {
-                    "off": "Aus",
-                    "manual": "Manuell",
-                    "auto": "Automatisch"
-                }
-            },
-            "indoor_humidity": {
-                "name": "Luftfeuchtigkeit innen"
-            },
-            "flame_indication": {
-                "name": "Flammenanzeige"
-            },
-            "energy_history": {
-                "name": "Energieverlauf"
-            },
-            "ventilation": {
-                "name": "{zone} Stufe",
-                "state": {
-                    "off": "Aus",
-                    "min": "Stufe 1 (Minimum)",
-                    "red": "Stufe 2 (Reduziert)",
-                    "nom": "Stufe 3 (Normal)",
-                    "max": "Stufe 4 (Maximum)",
-                    "dem": "Bedarfsgeregelt"
-                }
-            },
-            "wb_state": {
-                "name": "Wallbox Status",
-                "state": {
-                    "available": "Bereit",
-                    "authenticated": "Authentifiziert",
-                    "preparing": "Warte auf Freigabe",
-                    "locked": "Gesperrt",
-                    "charging": "Lädt",
-                    "suspendedev": "Fahrzeug pausiert",
-                    "suspendedevse": "Wallbox pausiert",
-                    "init": "Initialisierung",
-                    "faulted": "Störung",
-                    "limited": "Gedrosselt",
-                    "phaseswitch": "Phasenumschaltung"
-                }
-            },
-            "wb_power": {
-                "name": "Wallbox Leistung"
-            },
-            "wb_energy_total": {
-                "name": "Wallbox Energie Gesamt"
-            },
-            "wb_temperature": {
-                "name": "Wallbox Temperatur"
-            },
-            "wb_phases": {
-                "name": "Wallbox Phasen"
-            },
-            "wb_phase_sensor": {
-                "name": "Wallbox Phase"
-            },
-            "wb_chargelog": {
-                "name": "Wallbox Ladeprotokoll"
-            },
-            "thermostat_room_temp": {
-                "name": "Raumtemperatur"
-            },
-            "thermostat_humidity": {
-                "name": "Raumfeuchtigkeit"
-            },
-            "thermostat_setpoint": {
-                "name": "Raumsollwert"
-            },
-            "thermostat_battery": {
-                "name": "Batterie"
-            },
-            "thermostat_signal": {
-                "name": "Signalstärke"
-            },
-            "dhw": {
-                "name": "{circuit} Temperatur"
-            },
-            "hs": {
-                "name": "Wärmequelle"
-            },
-            "outdoor_temp": {
-                "name": "Außentemperatur"
-            },
-            "notifications": {
-                "name": "Benachrichtigungen"
-            },
-            "energy_history_hourly": {
-                "name": "Energieverlauf (stündlich)"
-            }
-        },
-        "binary_sensor": {
-            "wb_network": {
-                "name": "Wallbox Netzwerk"
-            },
-            "thermostat_rf_status": {
-                "name": "Funkverbindung"
-            }
-        },
-        "number": {
-            "wb_price": {
-                "name": "Strompreis"
-            },
-            "wb_charge_limit": {
-                "name": "Ladestromlimit"
-            },
-            "ventilation_summer_duration": {
-                "name": "Sommer-Bypass Dauer"
-            }
-        },
-        "button": {
-            "wb_authenticate": {
-                "name": "Laden authentifizieren"
-            },
-            "wb_start_charging": {
-                "name": "Laden starten"
-            },
-            "wb_pause_charging": {
-                "name": "Laden pausieren"
-            }
-        },
-        "switch": {
-            "child_lock": {
-                "name": "Kindersicherung"
-            },
-            "wb_locked": {
-                "name": "Wallbox Gesperrt"
-            },
-            "wb_auth": {
-                "name": "Wallbox Authentifizierung"
-            },
-            "wb_rfid_secure": {
-                "name": "Wallbox RFID Sicher"
-            },
-            "plasmacluster": {
-                "name": "Plasmacluster"
-            }
-        },
-        "water_heater": {
-            "dhw": {
-                "name": "Warmwasser {circuit}",
-                "state_attributes": {
-                    "operation_mode": {
-                        "state": {
-                            "off": "Aus",
-                            "low": "Niedrig (Eco)",
-                            "high": "Hoch (Komfort)",
-                            "eco": "Eco+",
-                            "manual": "Manuell",
-                            "ownprogram": "Eigenes Programm"
-                        }
-                    }
-                }
-            }
-        }
+    "abort": {
+      "already_configured": "Bereits konfiguriert",
+      "device_unsupported": "Das Gerät wird nicht unterstützt.",
+      "reauth_successful": "Erneute Authentifizierung erfolgreich",
+      "reauth_unsuccessful": "Die erneute Authentifizierung war nicht erfolgreich. Bitte entfernen Sie die Integration und richten Sie sie erneut ein.",
+      "reconfigure_successful": "Neukonfiguration erfolgreich"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Optionen",
+        "description": "Laufzeitoptionen für Bosch HomeCom anpassen.",
+        "data": {
+          "update_seconds": "Aktualisierungsintervall (Sekunden)",
+          "brand_buderus": "Buderus Marke",
+          "wb_label": "Wallbox Bezeichnung"
+        }
+      }
+    }
+  },
+  "entity": {
+    "climate": {
+      "zone": {
+        "name": "Zone {zone}"
+      },
+      "ac": {
+        "name": "Klimaanlage"
+      },
+      "hc": {
+        "name": "Heizkreis {circuit}"
+      }
+    },
+    "fan": {
+      "ventilation": {
+        "name": "Lüftung {zone}",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "off": "Aus",
+              "min": "Stufe 1 (Minimum)",
+              "red": "Stufe 2 (Reduziert)",
+              "nom": "Stufe 3 (Normal)",
+              "max": "Stufe 4 (Maximum)",
+              "dem": "Bedarfsgeregelt",
+              "powerVent": "Intensivlüftung",
+              "fallAsleep": "Schlafen",
+              "time": "Auto",
+              "party": "Party",
+              "fireplace": "Kamin"
+            }
+          }
+        }
+      }
+    },
+    "select": {
+      "airflow_horizontal": {
+        "name": "Luftstrom horizontal",
+        "state": {
+          "center": "Mitte",
+          "left": "Links",
+          "right": "Rechts",
+          "swing": "Schwenken"
+        }
+      },
+      "airflow_vertical": {
+        "name": "Luftstrom vertikal",
+        "state": {
+          "auto": "Automatisch",
+          "angle1": "Winkel 1",
+          "angle2": "Winkel 2",
+          "angle3": "Winkel 3",
+          "angle4": "Winkel 4",
+          "angle5": "Winkel 5",
+          "swing": "Schwenken"
+        }
+      },
+      "program": {
+        "name": "Programm",
+        "state": {
+          "off": "Aus",
+          "program1": "Programm 1",
+          "program2": "Programm 2"
+        }
+      },
+      "dhw_operation_mode": {
+        "name": "{circuit} Betriebsmodus",
+        "state": {
+          "off": "Aus",
+          "low": "Niedrig (Eco)",
+          "high": "Hoch (Komfort)",
+          "eco": "Eco+",
+          "ownprogram": "Eigenes Programm",
+          "manual": "Manuell"
+        }
+      },
+      "dhw_current_temp": {
+        "name": "{circuit} Temperaturstufe",
+        "state": {
+          "off": "Aus",
+          "low": "Niedrig",
+          "high": "Hoch",
+          "eco": "Eco"
+        }
+      },
+      "hc_operation_mode": {
+        "name": "{circuit} Betriebsmodus",
+        "state": {
+          "off": "Aus",
+          "manual": "Manuell",
+          "auto": "Automatisch"
+        }
+      },
+      "hc_suwi_mode": {
+        "name": "{circuit} Sommer/Winter",
+        "state": {
+          "forced": "Erzwungen",
+          "off": "Aus",
+          "cooling": "Kühlung"
+        }
+      },
+      "hc_heatcool_mode": {
+        "name": "{circuit} Heizen/Kühlen",
+        "state": {
+          "heat": "Heizen",
+          "cool": "Kühlen"
+        }
+      },
+      "holiday_mode": {
+        "name": "Urlaubsmodus",
+        "state": {
+          "hm1": "Urlaubsmodus 1",
+          "hm2": "Urlaubsmodus 2",
+          "hm3": "Urlaubsmodus 3",
+          "hm4": "Urlaubsmodus 4",
+          "hm5": "Urlaubsmodus 5",
+          "hm6": "Urlaubsmodus 6",
+          "hm7": "Urlaubsmodus 7",
+          "hm8": "Urlaubsmodus 8"
+        }
+      },
+      "away_mode": {
+        "name": "Abwesenheit",
+        "state": {
+          "on": "An",
+          "off": "Aus"
+        }
+      },
+      "hc_night_switch_mode": {
+        "name": "{circuit} Nachtabschaltung"
+      },
+      "hc_control": {
+        "name": "{circuit} Regelung"
+      },
+      "ventilation_summer_enable": {
+        "name": "{zone} Sommer-Bypass",
+        "state": {
+          "no": "Aus",
+          "yes": "An"
+        }
+      },
+      "wb_charging_strategy": {
+        "name": "Ladestrategie",
+        "state": {
+          "default": "Standard",
+          "solar-eco": "Solar-Eco"
+        }
+      }
+    },
+    "sensor": {
+      "hc": {
+        "name": "{circuit} Status",
+        "state": {
+          "off": "Aus",
+          "manual": "Manuell",
+          "auto": "Automatisch"
+        }
+      },
+      "indoor_humidity": {
+        "name": "Luftfeuchtigkeit innen"
+      },
+      "flame_indication": {
+        "name": "Flammenanzeige"
+      },
+      "energy_history": {
+        "name": "Energieverlauf"
+      },
+      "ventilation": {
+        "name": "{zone} Stufe",
+        "state": {
+          "off": "Aus",
+          "min": "Stufe 1 (Minimum)",
+          "red": "Stufe 2 (Reduziert)",
+          "nom": "Stufe 3 (Normal)",
+          "max": "Stufe 4 (Maximum)",
+          "dem": "Bedarfsgeregelt"
+        }
+      },
+      "wb_state": {
+        "name": "Wallbox Status",
+        "state": {
+          "available": "Bereit",
+          "authenticated": "Authentifiziert",
+          "preparing": "Warte auf Freigabe",
+          "locked": "Gesperrt",
+          "charging": "Lädt",
+          "suspendedev": "Fahrzeug pausiert",
+          "suspendedevse": "Wallbox pausiert",
+          "init": "Initialisierung",
+          "faulted": "Störung",
+          "limited": "Gedrosselt",
+          "phaseswitch": "Phasenumschaltung"
+        }
+      },
+      "wb_power": {
+        "name": "Wallbox Leistung"
+      },
+      "wb_energy_total": {
+        "name": "Wallbox Energie Gesamt"
+      },
+      "wb_temperature": {
+        "name": "Wallbox Temperatur"
+      },
+      "wb_phases": {
+        "name": "Wallbox Phasen"
+      },
+      "wb_phase_sensor": {
+        "name": "Wallbox Phase"
+      },
+      "wb_chargelog": {
+        "name": "Wallbox Ladeprotokoll"
+      },
+      "thermostat_room_temp": {
+        "name": "Raumtemperatur"
+      },
+      "thermostat_humidity": {
+        "name": "Raumfeuchtigkeit"
+      },
+      "thermostat_setpoint": {
+        "name": "Raumsollwert"
+      },
+      "thermostat_battery": {
+        "name": "Batterie"
+      },
+      "thermostat_signal": {
+        "name": "Signalstärke"
+      },
+      "dhw": {
+        "name": "{circuit} Temperatur"
+      },
+      "hs": {
+        "name": "Wärmequelle"
+      },
+      "outdoor_temp": {
+        "name": "Außentemperatur"
+      },
+      "notifications": {
+        "name": "Benachrichtigungen"
+      },
+      "energy_history_hourly": {
+        "name": "Energieverlauf (stündlich)"
+      }
+    },
+    "binary_sensor": {
+      "wb_network": {
+        "name": "Wallbox Netzwerk"
+      },
+      "thermostat_rf_status": {
+        "name": "Funkverbindung"
+      }
+    },
+    "number": {
+      "wb_price": {
+        "name": "Strompreis"
+      },
+      "wb_charge_limit": {
+        "name": "Ladestromlimit"
+      },
+      "ventilation_summer_duration": {
+        "name": "Sommer-Bypass Dauer"
+      }
+    },
+    "button": {
+      "wb_authenticate": {
+        "name": "Laden authentifizieren"
+      },
+      "wb_start_charging": {
+        "name": "Laden starten"
+      },
+      "wb_pause_charging": {
+        "name": "Laden pausieren"
+      }
+    },
+    "switch": {
+      "child_lock": {
+        "name": "Kindersicherung"
+      },
+      "wb_locked": {
+        "name": "Wallbox Gesperrt"
+      },
+      "wb_auth": {
+        "name": "Wallbox Authentifizierung"
+      },
+      "wb_rfid_secure": {
+        "name": "Wallbox RFID Sicher"
+      },
+      "plasmacluster": {
+        "name": "Plasmacluster"
+      }
+    },
+    "water_heater": {
+      "dhw": {
+        "name": "Warmwasser {circuit}",
+        "state_attributes": {
+          "operation_mode": {
+            "state": {
+              "off": "Aus",
+              "low": "Niedrig (Eco)",
+              "high": "Hoch (Komfort)",
+              "eco": "Eco+",
+              "manual": "Manuell",
+              "ownprogram": "Eigenes Programm"
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/custom_components/bosch_homecom/translations/de.json
+++ b/custom_components/bosch_homecom/translations/de.json
@@ -353,7 +353,7 @@
     },
     "water_heater": {
       "dhw": {
-        "name": "Warmwasser {circuit}",
+        "name": "Warmwasser{circuit}",
         "state_attributes": {
           "operation_mode": {
             "state": {

--- a/custom_components/bosch_homecom/translations/de.json
+++ b/custom_components/bosch_homecom/translations/de.json
@@ -353,7 +353,7 @@
     },
     "water_heater": {
       "dhw": {
-        "name": "Warmwasser{circuit}",
+        "name": "Warmwasser {circuit}",
         "state_attributes": {
           "operation_mode": {
             "state": {

--- a/custom_components/bosch_homecom/translations/en.json
+++ b/custom_components/bosch_homecom/translations/en.json
@@ -1,370 +1,370 @@
 {
-    "config": {
-        "step": {
-            "user": {
-                "data": {
-                    "username": "SingleKey ID username",
-                    "password": "SingleKey ID password"
-                },
-                "description": "Enter your SingleKey ID Credentials",
-                "title": "Authentication"
-            },
-            "reauth_confirm": {
-                "description": "Please enter the correct username and password for SingleKey ID",
-                "data": {
-                    "username": "SingleKey ID username",
-                    "password": "SingleKey ID password"
-                }
-            },
-            "reconfigure": {
-                "description": "Update configuration for SingleKey ID.",
-                "data": {
-                    "username": "SingleKey ID username",
-                    "password": "SingleKey ID password"
-                },
-                "title": "Authentication"
-            },
-            "browser": {
-                "description": "Login in browser using [URL]({url}) in readme and capture code using browser's developer tools.",
-                "data": {
-                    "code": "SingleKey ID code"
-                },
-                "title": "Browser Authentication"
-            }
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "username": "SingleKey ID username",
+          "password": "SingleKey ID password"
         },
-        "error": {
-            "username_required": "Username is required.",
-            "code_required": "Verification code is required.",
-            "unknown": "An unknown error occurred.",
-            "cannot_connect": "Cannot connect to Bosch servers.",
-            "no_devices_found": "No devices found.",
-            "no_device_selected": "You must select at least one device.",
-            "already_configured": "This account is already configured."
-        },
-        "abort": {
-            "already_configured": "Already configured",
-            "device_unsupported": "The device is unsupported.",
-            "reauth_successful": "Reauth successful",
-            "reauth_unsuccessful": "Re-authentication was unsuccessful, please remove the integration and set it up again.",
-            "reconfigure_successful": "Reconfigure successful"
+        "description": "Enter your SingleKey ID Credentials",
+        "title": "Authentication"
+      },
+      "reauth_confirm": {
+        "description": "Please enter the correct username and password for SingleKey ID",
+        "data": {
+          "username": "SingleKey ID username",
+          "password": "SingleKey ID password"
         }
+      },
+      "reconfigure": {
+        "description": "Update configuration for SingleKey ID.",
+        "data": {
+          "username": "SingleKey ID username",
+          "password": "SingleKey ID password"
+        },
+        "title": "Authentication"
+      },
+      "browser": {
+        "description": "Login in browser using [URL]({url}) in readme and capture code using browser's developer tools.",
+        "data": {
+          "code": "SingleKey ID code"
+        },
+        "title": "Browser Authentication"
+      }
     },
-    "options": {
-        "step": {
-            "init": {
-                "title": "Options",
-                "description": "Adjust runtime options for Bosch HomeCom.",
-                "data": {
-                    "update_seconds": "Update interval (seconds)",
-                    "brand_buderus": "Buderus brand",
-                    "wb_label": "Wallbox label"
-                }
-            }
-        }
+    "error": {
+      "username_required": "Username is required.",
+      "code_required": "Verification code is required.",
+      "unknown": "An unknown error occurred.",
+      "cannot_connect": "Cannot connect to Bosch servers.",
+      "no_devices_found": "No devices found.",
+      "no_device_selected": "You must select at least one device.",
+      "already_configured": "This account is already configured."
     },
-    "entity": {
-        "climate": {
-            "zone": {
-                "name": "Zone"
-            },
-            "ac": {
-                "name": "Air conditioner"
-            },
-            "hc": {
-                "name": "Heating circuit {circuit}"
-            }
-        },
-        "fan": {
-            "ventilation": {
-                "name": "Ventilation {zone}",
-                "state_attributes": {
-                    "preset_mode": {
-                        "state": {
-                            "off": "Off",
-                            "min": "Level 1 (Minimum)",
-                            "red": "Level 2 (Reduced)",
-                            "nom": "Level 3 (Normal)",
-                            "max": "Level 4 (Maximum)",
-                            "dem": "Demand-based",
-                            "time": "Time-based",
-                            "party": "Party",
-                            "fireplace": "Fireplace"
-                        }
-                    }
-                }
-            }
-        },
-        "select": {
-            "airflow_horizontal": {
-                "name": "Horizontal airflow",
-                "state": {
-                    "center": "Center",
-                    "left": "Left",
-                    "right": "Right",
-                    "swing": "Swing"
-                }
-            },
-            "airflow_vertical": {
-                "name": "Vertical airflow",
-                "state": {
-                    "auto": "Auto",
-                    "angle1": "Angle 1",
-                    "angle2": "Angle 2",
-                    "angle3": "Angle 3",
-                    "angle4": "Angle 4",
-                    "angle5": "Angle 5",
-                    "swing": "Swing"
-                }
-            },
-            "program": {
-                "name": "Program",
-                "state": {
-                    "off": "Off",
-                    "program1": "Program 1",
-                    "program2": "Program 2"
-                }
-            },
-            "dhw_operation_mode": {
-                "name": "{circuit} operation mode",
-                "state": {
-                    "off": "Off",
-                    "low": "Low (Eco)",
-                    "high": "High (Comfort)",
-                    "eco": "Eco+",
-                    "ownprogram": "Own program",
-                    "manual": "Manual"
-                }
-            },
-            "dhw_current_temp": {
-                "name": "{circuit} temperature level",
-                "state": {
-                    "off": "Off",
-                    "low": "Low",
-                    "high": "High",
-                    "eco": "Eco"
-                }
-            },
-            "hc_operation_mode": {
-                "name": "{circuit} operation mode",
-                "state": {
-                    "off": "Off",
-                    "manual": "Manual",
-                    "auto": "Auto"
-                }
-            },
-            "hc_suwi_mode": {
-                "name": "{circuit} summer/winter mode",
-                "state": {
-                    "forced": "Forced",
-                    "off": "Off",
-                    "cooling": "Cooling"
-                }
-            },
-            "hc_heatcool_mode": {
-                "name": "{circuit} heat/cool mode",
-                "state": {
-                    "heat": "Heat",
-                    "cool": "Cool"
-                }
-            },
-            "holiday_mode": {
-                "name": "Holiday mode",
-                "state": {
-                    "hm1": "Holiday mode 1",
-                    "hm2": "Holiday mode 2",
-                    "hm3": "Holiday mode 3",
-                    "hm4": "Holiday mode 4",
-                    "hm5": "Holiday mode 5",
-                    "hm6": "Holiday mode 6",
-                    "hm7": "Holiday mode 7",
-                    "hm8": "Holiday mode 8"
-                }
-            },
-            "away_mode": {
-                "name": "Away mode",
-                "state": {
-                    "on": "On",
-                    "off": "Off"
-                }
-            },
-            "hc_night_switch_mode": {
-                "name": "HC Night Switch Mode"
-            },
-            "hc_control": {
-                "name": "HC Control"
-            },
-            "ventilation_summer_enable": {
-                "name": "Summer bypass",
-                "state": {
-                    "no": "Off",
-                    "yes": "On"
-                }
-            },
-            "wb_charging_strategy": {
-                "name": "Charging Strategy",
-                "state": {
-                    "default": "Default",
-                    "solar-eco": "Solar Eco"
-                }
-            }
-        },
-        "sensor": {
-            "hc": {
-                "name": "{circuit} status",
-                "state": {
-                    "off": "Off",
-                    "manual": "Manual",
-                    "auto": "Auto"
-                }
-            },
-            "indoor_humidity": {
-                "name": "Indoor Humidity"
-            },
-            "flame_indication": {
-                "name": "Flame Indication"
-            },
-            "energy_history": {
-                "name": "Energy History"
-            },
-            "ventilation": {
-                "name": "{zone} level",
-                "state": {
-                    "off": "Off",
-                    "min": "Level 1 (Minimum)",
-                    "red": "Level 2 (Reduced)",
-                    "nom": "Level 3 (Normal)",
-                    "max": "Level 4 (Maximum)",
-                    "dem": "Demand-based"
-                }
-            },
-            "wb_state": {
-                "name": "Wallbox State",
-                "state": {
-                    "available": "Available",
-                    "authenticated": "Authenticated",
-                    "preparing": "Awaiting Authorization",
-                    "locked": "Locked",
-                    "charging": "Charging",
-                    "suspendedev": "Vehicle Paused",
-                    "suspendedevse": "Wallbox Paused",
-                    "init": "Initializing",
-                    "faulted": "Faulted",
-                    "limited": "Power Limited",
-                    "phaseswitch": "Phase Switching"
-                }
-            },
-            "wb_power": {
-                "name": "Wallbox Power"
-            },
-            "wb_energy_total": {
-                "name": "Wallbox Energy Total"
-            },
-            "wb_temperature": {
-                "name": "Wallbox Temperature"
-            },
-            "wb_phases": {
-                "name": "Wallbox Phases"
-            },
-            "wb_phase_sensor": {
-                "name": "Wallbox Phase"
-            },
-            "wb_chargelog": {
-                "name": "Wallbox Charge Log"
-            },
-            "thermostat_room_temp": {
-                "name": "Room Temperature"
-            },
-            "thermostat_humidity": {
-                "name": "Room Humidity"
-            },
-            "thermostat_setpoint": {
-                "name": "Room Setpoint"
-            },
-            "thermostat_battery": {
-                "name": "Battery"
-            },
-            "thermostat_signal": {
-                "name": "Signal Strength"
-            },
-            "dhw": {
-                "name": "{circuit} temperature"
-            },
-            "hs": {
-                "name": "Heat source"
-            },
-            "outdoor_temp": {
-                "name": "Outdoor temperature"
-            },
-            "notifications": {
-                "name": "Notifications"
-            },
-            "energy_history_hourly": {
-                "name": "Energy history (hourly)"
-            }
-        },
-        "binary_sensor": {
-            "wb_network": {
-                "name": "Wallbox Network"
-            },
-            "thermostat_rf_status": {
-                "name": "RF Connection"
-            }
-        },
-        "number": {
-            "wb_price": {
-                "name": "Electricity Price"
-            },
-            "wb_charge_limit": {
-                "name": "Charging Limit"
-            },
-            "ventilation_summer_duration": {
-                "name": "Summer bypass duration"
-            }
-        },
-        "button": {
-            "wb_authenticate": {
-                "name": "Authenticate Charging"
-            },
-            "wb_start_charging": {
-                "name": "Start Charging"
-            },
-            "wb_pause_charging": {
-                "name": "Pause Charging"
-            }
-        },
-        "switch": {
-            "child_lock": {
-                "name": "Child Lock"
-            },
-            "wb_locked": {
-                "name": "Wallbox Locked"
-            },
-            "wb_auth": {
-                "name": "Wallbox Auth"
-            },
-            "wb_rfid_secure": {
-                "name": "Wallbox RFID Secure"
-            },
-            "plasmacluster": {
-                "name": "Plasmacluster"
-            }
-        },
-        "water_heater": {
-            "dhw": {
-                "name": "Water heater {circuit}",
-                "state_attributes": {
-                    "operation_mode": {
-                        "state": {
-                            "off": "Off",
-                            "low": "Low (Eco)",
-                            "high": "High (Comfort)",
-                            "eco": "Eco+",
-                            "manual": "Manual",
-                            "ownprogram": "Own program"
-                        }
-                    }
-                }
-            }
-        }
+    "abort": {
+      "already_configured": "Already configured",
+      "device_unsupported": "The device is unsupported.",
+      "reauth_successful": "Reauth successful",
+      "reauth_unsuccessful": "Re-authentication was unsuccessful, please remove the integration and set it up again.",
+      "reconfigure_successful": "Reconfigure successful"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options",
+        "description": "Adjust runtime options for Bosch HomeCom.",
+        "data": {
+          "update_seconds": "Update interval (seconds)",
+          "brand_buderus": "Buderus brand",
+          "wb_label": "Wallbox label"
+        }
+      }
+    }
+  },
+  "entity": {
+    "climate": {
+      "zone": {
+        "name": "Zone {zone}"
+      },
+      "ac": {
+        "name": "Air conditioner"
+      },
+      "hc": {
+        "name": "Heating circuit {circuit}"
+      }
+    },
+    "fan": {
+      "ventilation": {
+        "name": "Ventilation {zone}",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "off": "Off",
+              "min": "Level 1 (Minimum)",
+              "red": "Level 2 (Reduced)",
+              "nom": "Level 3 (Normal)",
+              "max": "Level 4 (Maximum)",
+              "dem": "Demand-based",
+              "time": "Time-based",
+              "party": "Party",
+              "fireplace": "Fireplace"
+            }
+          }
+        }
+      }
+    },
+    "select": {
+      "airflow_horizontal": {
+        "name": "Horizontal airflow",
+        "state": {
+          "center": "Center",
+          "left": "Left",
+          "right": "Right",
+          "swing": "Swing"
+        }
+      },
+      "airflow_vertical": {
+        "name": "Vertical airflow",
+        "state": {
+          "auto": "Auto",
+          "angle1": "Angle 1",
+          "angle2": "Angle 2",
+          "angle3": "Angle 3",
+          "angle4": "Angle 4",
+          "angle5": "Angle 5",
+          "swing": "Swing"
+        }
+      },
+      "program": {
+        "name": "Program",
+        "state": {
+          "off": "Off",
+          "program1": "Program 1",
+          "program2": "Program 2"
+        }
+      },
+      "dhw_operation_mode": {
+        "name": "{circuit} operation mode",
+        "state": {
+          "off": "Off",
+          "low": "Low (Eco)",
+          "high": "High (Comfort)",
+          "eco": "Eco+",
+          "ownprogram": "Own program",
+          "manual": "Manual"
+        }
+      },
+      "dhw_current_temp": {
+        "name": "{circuit} temperature level",
+        "state": {
+          "off": "Off",
+          "low": "Low",
+          "high": "High",
+          "eco": "Eco"
+        }
+      },
+      "hc_operation_mode": {
+        "name": "{circuit} operation mode",
+        "state": {
+          "off": "Off",
+          "manual": "Manual",
+          "auto": "Auto"
+        }
+      },
+      "hc_suwi_mode": {
+        "name": "{circuit} summer/winter mode",
+        "state": {
+          "forced": "Forced",
+          "off": "Off",
+          "cooling": "Cooling"
+        }
+      },
+      "hc_heatcool_mode": {
+        "name": "{circuit} heat/cool mode",
+        "state": {
+          "heat": "Heat",
+          "cool": "Cool"
+        }
+      },
+      "holiday_mode": {
+        "name": "Holiday mode",
+        "state": {
+          "hm1": "Holiday mode 1",
+          "hm2": "Holiday mode 2",
+          "hm3": "Holiday mode 3",
+          "hm4": "Holiday mode 4",
+          "hm5": "Holiday mode 5",
+          "hm6": "Holiday mode 6",
+          "hm7": "Holiday mode 7",
+          "hm8": "Holiday mode 8"
+        }
+      },
+      "away_mode": {
+        "name": "Away mode",
+        "state": {
+          "on": "On",
+          "off": "Off"
+        }
+      },
+      "hc_night_switch_mode": {
+        "name": "{circuit} night switch mode"
+      },
+      "hc_control": {
+        "name": "{circuit} control"
+      },
+      "ventilation_summer_enable": {
+        "name": "{zone} summer bypass",
+        "state": {
+          "no": "Off",
+          "yes": "On"
+        }
+      },
+      "wb_charging_strategy": {
+        "name": "Charging Strategy",
+        "state": {
+          "default": "Default",
+          "solar-eco": "Solar Eco"
+        }
+      }
+    },
+    "sensor": {
+      "hc": {
+        "name": "{circuit} status",
+        "state": {
+          "off": "Off",
+          "manual": "Manual",
+          "auto": "Auto"
+        }
+      },
+      "indoor_humidity": {
+        "name": "Indoor Humidity"
+      },
+      "flame_indication": {
+        "name": "Flame Indication"
+      },
+      "energy_history": {
+        "name": "Energy History"
+      },
+      "ventilation": {
+        "name": "{zone} level",
+        "state": {
+          "off": "Off",
+          "min": "Level 1 (Minimum)",
+          "red": "Level 2 (Reduced)",
+          "nom": "Level 3 (Normal)",
+          "max": "Level 4 (Maximum)",
+          "dem": "Demand-based"
+        }
+      },
+      "wb_state": {
+        "name": "Wallbox State",
+        "state": {
+          "available": "Available",
+          "authenticated": "Authenticated",
+          "preparing": "Awaiting Authorization",
+          "locked": "Locked",
+          "charging": "Charging",
+          "suspendedev": "Vehicle Paused",
+          "suspendedevse": "Wallbox Paused",
+          "init": "Initializing",
+          "faulted": "Faulted",
+          "limited": "Power Limited",
+          "phaseswitch": "Phase Switching"
+        }
+      },
+      "wb_power": {
+        "name": "Wallbox Power"
+      },
+      "wb_energy_total": {
+        "name": "Wallbox Energy Total"
+      },
+      "wb_temperature": {
+        "name": "Wallbox Temperature"
+      },
+      "wb_phases": {
+        "name": "Wallbox Phases"
+      },
+      "wb_phase_sensor": {
+        "name": "Wallbox Phase"
+      },
+      "wb_chargelog": {
+        "name": "Wallbox Charge Log"
+      },
+      "thermostat_room_temp": {
+        "name": "Room Temperature"
+      },
+      "thermostat_humidity": {
+        "name": "Room Humidity"
+      },
+      "thermostat_setpoint": {
+        "name": "Room Setpoint"
+      },
+      "thermostat_battery": {
+        "name": "Battery"
+      },
+      "thermostat_signal": {
+        "name": "Signal Strength"
+      },
+      "dhw": {
+        "name": "{circuit} temperature"
+      },
+      "hs": {
+        "name": "Heat source"
+      },
+      "outdoor_temp": {
+        "name": "Outdoor temperature"
+      },
+      "notifications": {
+        "name": "Notifications"
+      },
+      "energy_history_hourly": {
+        "name": "Energy history (hourly)"
+      }
+    },
+    "binary_sensor": {
+      "wb_network": {
+        "name": "Wallbox Network"
+      },
+      "thermostat_rf_status": {
+        "name": "RF Connection"
+      }
+    },
+    "number": {
+      "wb_price": {
+        "name": "Electricity Price"
+      },
+      "wb_charge_limit": {
+        "name": "Charging Limit"
+      },
+      "ventilation_summer_duration": {
+        "name": "Summer bypass duration"
+      }
+    },
+    "button": {
+      "wb_authenticate": {
+        "name": "Authenticate Charging"
+      },
+      "wb_start_charging": {
+        "name": "Start Charging"
+      },
+      "wb_pause_charging": {
+        "name": "Pause Charging"
+      }
+    },
+    "switch": {
+      "child_lock": {
+        "name": "Child Lock"
+      },
+      "wb_locked": {
+        "name": "Wallbox Locked"
+      },
+      "wb_auth": {
+        "name": "Wallbox Auth"
+      },
+      "wb_rfid_secure": {
+        "name": "Wallbox RFID Secure"
+      },
+      "plasmacluster": {
+        "name": "Plasmacluster"
+      }
+    },
+    "water_heater": {
+      "dhw": {
+        "name": "Water heater {circuit}",
+        "state_attributes": {
+          "operation_mode": {
+            "state": {
+              "off": "Off",
+              "low": "Low (Eco)",
+              "high": "High (Comfort)",
+              "eco": "Eco+",
+              "manual": "Manual",
+              "ownprogram": "Own program"
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/custom_components/bosch_homecom/translations/en.json
+++ b/custom_components/bosch_homecom/translations/en.json
@@ -351,7 +351,7 @@
     },
     "water_heater": {
       "dhw": {
-        "name": "Water heater {circuit}",
+        "name": "Water heater{circuit}",
         "state_attributes": {
           "operation_mode": {
             "state": {

--- a/custom_components/bosch_homecom/translations/en.json
+++ b/custom_components/bosch_homecom/translations/en.json
@@ -318,7 +318,7 @@
         "name": "Charging Limit"
       },
       "ventilation_summer_duration": {
-        "name": "Summer bypass duration"
+        "name": "{zone} summer bypass duration"
       }
     },
     "button": {

--- a/custom_components/bosch_homecom/translations/en.json
+++ b/custom_components/bosch_homecom/translations/en.json
@@ -351,7 +351,7 @@
     },
     "water_heater": {
       "dhw": {
-        "name": "Water heater",
+        "name": "Water heater {circuit}",
         "state_attributes": {
           "operation_mode": {
             "state": {

--- a/custom_components/bosch_homecom/translations/en.json
+++ b/custom_components/bosch_homecom/translations/en.json
@@ -351,7 +351,7 @@
     },
     "water_heater": {
       "dhw": {
-        "name": "Water heater{circuit}",
+        "name": "Water heater {circuit}",
         "state_attributes": {
           "operation_mode": {
             "state": {

--- a/custom_components/bosch_homecom/translations/en.json
+++ b/custom_components/bosch_homecom/translations/en.json
@@ -351,7 +351,7 @@
     },
     "water_heater": {
       "dhw": {
-        "name": "Water heater {circuit}",
+        "name": "Water heater",
         "state_attributes": {
           "operation_mode": {
             "state": {

--- a/custom_components/bosch_homecom/translations/nl.json
+++ b/custom_components/bosch_homecom/translations/nl.json
@@ -1,370 +1,370 @@
 {
-    "config": {
-        "step": {
-            "user": {
-                "data": {
-                    "username": "SingleKey ID gebruikersnaam",
-                    "password": "SingleKey ID wachtwoord"
-                },
-                "description": "Voer je SingleKey ID inloggegevens in.",
-                "title": "Authenticatie"
-            },
-            "reauth_confirm": {
-                "description": "Voer de juiste gebruikersnaam en het juiste wachtwoord in voor SingleKey ID.",
-                "data": {
-                    "username": "SingleKey ID gebruikersnaam",
-                    "password": "SingleKey ID wachtwoord"
-                }
-            },
-            "reconfigure": {
-                "description": "Werk de configuratie voor SingleKey ID bij.",
-                "data": {
-                    "username": "SingleKey ID gebruikersnaam",
-                    "password": "SingleKey ID wachtwoord"
-                },
-                "title": "Authenticatie"
-            },
-            "browser": {
-                "description": "Log in via de browser met de [URL]({url}) in de README en haal de code op via de ontwikkelaarstools van de browser.",
-                "data": {
-                    "code": "SingleKey ID-code"
-                },
-                "title": "Browser Authenticatie"
-            }
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "username": "SingleKey ID gebruikersnaam",
+          "password": "SingleKey ID wachtwoord"
         },
-        "error": {
-            "username_required": "Gebruikersnaam is verplicht.",
-            "code_required": "Verificatiecode is verplicht.",
-            "unknown": "Er is een onbekende fout opgetreden.",
-            "cannot_connect": "Kan geen verbinding maken met de Bosch-servers.",
-            "no_devices_found": "Geen apparaten gevonden.",
-            "no_device_selected": "Selecteer minimaal één apparaat.",
-            "already_configured": "Dit account is al ingesteld."
-        },
-        "abort": {
-            "already_configured": "Al ingesteld",
-            "device_unsupported": "Dit apparaat wordt niet ondersteund.",
-            "reauth_successful": "Opnieuw inloggen gelukt.",
-            "reauth_unsuccessful": "Opnieuw inloggen is mislukt. Verwijder de koppeling en stel deze opnieuw in.",
-            "reconfigure_successful": "Opnieuw instellen gelukt."
+        "description": "Voer je SingleKey ID inloggegevens in.",
+        "title": "Authenticatie"
+      },
+      "reauth_confirm": {
+        "description": "Voer de juiste gebruikersnaam en het juiste wachtwoord in voor SingleKey ID.",
+        "data": {
+          "username": "SingleKey ID gebruikersnaam",
+          "password": "SingleKey ID wachtwoord"
         }
+      },
+      "reconfigure": {
+        "description": "Werk de configuratie voor SingleKey ID bij.",
+        "data": {
+          "username": "SingleKey ID gebruikersnaam",
+          "password": "SingleKey ID wachtwoord"
+        },
+        "title": "Authenticatie"
+      },
+      "browser": {
+        "description": "Log in via de browser met de [URL]({url}) in de README en haal de code op via de ontwikkelaarstools van de browser.",
+        "data": {
+          "code": "SingleKey ID-code"
+        },
+        "title": "Browser Authenticatie"
+      }
     },
-    "options": {
-        "step": {
-            "init": {
-                "title": "Opties",
-                "description": "Pas de instellingen voor Bosch HomeCom aan.",
-                "data": {
-                    "update_seconds": "Update-interval (seconden)",
-                    "brand_buderus": "Buderus merk",
-                    "wb_label": "Wallbox label"
-                }
-            }
-        }
+    "error": {
+      "username_required": "Gebruikersnaam is verplicht.",
+      "code_required": "Verificatiecode is verplicht.",
+      "unknown": "Er is een onbekende fout opgetreden.",
+      "cannot_connect": "Kan geen verbinding maken met de Bosch-servers.",
+      "no_devices_found": "Geen apparaten gevonden.",
+      "no_device_selected": "Selecteer minimaal één apparaat.",
+      "already_configured": "Dit account is al ingesteld."
     },
-    "entity": {
-        "climate": {
-            "zone": {
-                "name": "Zone"
-            },
-            "ac": {
-                "name": "Airconditioner"
-            },
-            "hc": {
-                "name": "Verwarmingscircuit {circuit}"
-            }
-        },
-        "fan": {
-            "ventilation": {
-                "name": "Ventilatie {zone}",
-                "state_attributes": {
-                    "preset_mode": {
-                        "state": {
-                            "off": "Uit",
-                            "min": "Niveau 1 (Minimaal)",
-                            "red": "Niveau 2 (Verminderd)",
-                            "nom": "Niveau 3 (Normaal)",
-                            "max": "Niveau 4 (Maximaal)",
-                            "dem": "Vraaggestuurd",
-                            "time": "Tijdgestuurd",
-                            "party": "Feest",
-                            "fireplace": "Open haard"
-                        }
-                    }
-                }
-            }
-        },
-        "select": {
-            "airflow_horizontal": {
-                "name": "Luchtstroom horizontaal",
-                "state": {
-                    "center": "Midden",
-                    "left": "Links",
-                    "right": "Rechts",
-                    "swing": "Heen en weer"
-                }
-            },
-            "airflow_vertical": {
-                "name": "Luchtstroom verticaal",
-                "state": {
-                    "auto": "Automatisch",
-                    "angle1": "Hoek 1",
-                    "angle2": "Hoek 2",
-                    "angle3": "Hoek 3",
-                    "angle4": "Hoek 4",
-                    "angle5": "Hoek 5",
-                    "swing": "Heen en weer"
-                }
-            },
-            "program": {
-                "name": "Programma",
-                "state": {
-                    "off": "Uit",
-                    "program1": "Programma 1",
-                    "program2": "Programma 2"
-                }
-            },
-            "dhw_operation_mode": {
-                "name": "{circuit} bedrijfsmodus",
-                "state": {
-                    "off": "Uit",
-                    "low": "Laag (Eco)",
-                    "high": "Hoog (Comfort)",
-                    "eco": "Eco+",
-                    "ownprogram": "Eigen programma",
-                    "manual": "Handmatig"
-                }
-            },
-            "dhw_current_temp": {
-                "name": "{circuit} temperatuurniveau",
-                "state": {
-                    "off": "Uit",
-                    "low": "Laag",
-                    "high": "Hoog",
-                    "eco": "Eco"
-                }
-            },
-            "hc_operation_mode": {
-                "name": "{circuit} bedrijfsmodus",
-                "state": {
-                    "off": "Uit",
-                    "manual": "Handmatig",
-                    "auto": "Automatisch"
-                }
-            },
-            "hc_suwi_mode": {
-                "name": "{circuit} zomer/winter",
-                "state": {
-                    "forced": "Geforceerd",
-                    "off": "Uit",
-                    "cooling": "Koelen"
-                }
-            },
-            "hc_heatcool_mode": {
-                "name": "{circuit} verwarmen/koelen",
-                "state": {
-                    "heat": "Verwarmen",
-                    "cool": "Koelen"
-                }
-            },
-            "holiday_mode": {
-                "name": "Vakantiemodus",
-                "state": {
-                    "hm1": "Vakantiemodus 1",
-                    "hm2": "Vakantiemodus 2",
-                    "hm3": "Vakantiemodus 3",
-                    "hm4": "Vakantiemodus 4",
-                    "hm5": "Vakantiemodus 5",
-                    "hm6": "Vakantiemodus 6",
-                    "hm7": "Vakantiemodus 7",
-                    "hm8": "Vakantiemodus 8"
-                }
-            },
-            "away_mode": {
-                "name": "Afwezigheidsmodus",
-                "state": {
-                    "on": "Aan",
-                    "off": "Uit"
-                }
-            },
-            "hc_night_switch_mode": {
-                "name": "HC Nacht Schakelmodus"
-            },
-            "hc_control": {
-                "name": "HC Besturing"
-            },
-            "ventilation_summer_enable": {
-                "name": "Zomerbypass",
-                "state": {
-                    "no": "Uit",
-                    "yes": "Aan"
-                }
-            },
-            "wb_charging_strategy": {
-                "name": "Laadstrategie",
-                "state": {
-                    "default": "Standaard",
-                    "solar-eco": "Solar-Eco"
-                }
-            }
-        },
-        "sensor": {
-            "hc": {
-                "name": "{circuit} status",
-                "state": {
-                    "off": "Uit",
-                    "manual": "Handmatig",
-                    "auto": "Automatisch"
-                }
-            },
-            "indoor_humidity": {
-                "name": "Binnenluchtvochtigheid"
-            },
-            "flame_indication": {
-                "name": "Vlamindicatie"
-            },
-            "energy_history": {
-                "name": "Energiegeschiedenis"
-            },
-            "ventilation": {
-                "name": "{zone} niveau",
-                "state": {
-                    "off": "Uit",
-                    "min": "Niveau 1 (Minimaal)",
-                    "red": "Niveau 2 (Verminderd)",
-                    "nom": "Niveau 3 (Normaal)",
-                    "max": "Niveau 4 (Maximaal)",
-                    "dem": "Vraaggestuurd"
-                }
-            },
-            "wb_state": {
-                "name": "Wallbox Status",
-                "state": {
-                    "available": "Available",
-                    "authenticated": "Authenticated",
-                    "preparing": "Awaiting Authorization",
-                    "locked": "Locked",
-                    "charging": "Charging",
-                    "suspendedev": "Vehicle Paused",
-                    "suspendedevse": "Wallbox Paused",
-                    "init": "Initializing",
-                    "faulted": "Faulted",
-                    "limited": "Power Limited",
-                    "phaseswitch": "Phase Switching"
-                }
-            },
-            "wb_power": {
-                "name": "Wallbox Vermogen"
-            },
-            "wb_energy_total": {
-                "name": "Wallbox Totale Energie"
-            },
-            "wb_temperature": {
-                "name": "Wallbox Temperatuur"
-            },
-            "wb_phases": {
-                "name": "Wallbox Fasen"
-            },
-            "wb_phase_sensor": {
-                "name": "Wallbox Fase"
-            },
-            "wb_chargelog": {
-                "name": "Wallbox Laadlogboek"
-            },
-            "thermostat_room_temp": {
-                "name": "Kamertemperatuur"
-            },
-            "thermostat_humidity": {
-                "name": "Kamervochtigheid"
-            },
-            "thermostat_setpoint": {
-                "name": "Kamer Instelpunt"
-            },
-            "thermostat_battery": {
-                "name": "Batterij"
-            },
-            "thermostat_signal": {
-                "name": "Signaalsterkte"
-            },
-            "dhw": {
-                "name": "{circuit} temperatuur"
-            },
-            "hs": {
-                "name": "Warmtebron"
-            },
-            "outdoor_temp": {
-                "name": "Buitentemperatuur"
-            },
-            "notifications": {
-                "name": "Meldingen"
-            },
-            "energy_history_hourly": {
-                "name": "Energiegeschiedenis (uurlijks)"
-            }
-        },
-        "binary_sensor": {
-            "wb_network": {
-                "name": "Wallbox Netwerk"
-            },
-            "thermostat_rf_status": {
-                "name": "RF Verbinding"
-            }
-        },
-        "number": {
-            "wb_price": {
-                "name": "Stroomprijs"
-            },
-            "wb_charge_limit": {
-                "name": "Laadlimiet"
-            },
-            "ventilation_summer_duration": {
-                "name": "Zomerbypass duur"
-            }
-        },
-        "button": {
-            "wb_authenticate": {
-                "name": "Laden authenticeren"
-            },
-            "wb_start_charging": {
-                "name": "Laden starten"
-            },
-            "wb_pause_charging": {
-                "name": "Laden pauzeren"
-            }
-        },
-        "switch": {
-            "child_lock": {
-                "name": "Kinderbeveiliging"
-            },
-            "wb_locked": {
-                "name": "Wallbox Vergrendeld"
-            },
-            "wb_auth": {
-                "name": "Wallbox Auth"
-            },
-            "wb_rfid_secure": {
-                "name": "Wallbox RFID Beveiligd"
-            },
-            "plasmacluster": {
-                "name": "Plasmacluster"
-            }
-        },
-        "water_heater": {
-            "dhw": {
-                "name": "Boiler {circuit}",
-                "state_attributes": {
-                    "operation_mode": {
-                        "state": {
-                            "off": "Uit",
-                            "low": "Laag (Eco)",
-                            "high": "Hoog (Comfort)",
-                            "eco": "Eco+",
-                            "manual": "Handmatig",
-                            "ownprogram": "Eigen programma"
-                        }
-                    }
-                }
-            }
-        }
+    "abort": {
+      "already_configured": "Al ingesteld",
+      "device_unsupported": "Dit apparaat wordt niet ondersteund.",
+      "reauth_successful": "Opnieuw inloggen gelukt.",
+      "reauth_unsuccessful": "Opnieuw inloggen is mislukt. Verwijder de koppeling en stel deze opnieuw in.",
+      "reconfigure_successful": "Opnieuw instellen gelukt."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opties",
+        "description": "Pas de instellingen voor Bosch HomeCom aan.",
+        "data": {
+          "update_seconds": "Update-interval (seconden)",
+          "brand_buderus": "Buderus merk",
+          "wb_label": "Wallbox label"
+        }
+      }
+    }
+  },
+  "entity": {
+    "climate": {
+      "zone": {
+        "name": "Zone {zone}"
+      },
+      "ac": {
+        "name": "Airconditioner"
+      },
+      "hc": {
+        "name": "Verwarmingscircuit {circuit}"
+      }
+    },
+    "fan": {
+      "ventilation": {
+        "name": "Ventilatie {zone}",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "off": "Uit",
+              "min": "Niveau 1 (Minimaal)",
+              "red": "Niveau 2 (Verminderd)",
+              "nom": "Niveau 3 (Normaal)",
+              "max": "Niveau 4 (Maximaal)",
+              "dem": "Vraaggestuurd",
+              "time": "Tijdgestuurd",
+              "party": "Feest",
+              "fireplace": "Open haard"
+            }
+          }
+        }
+      }
+    },
+    "select": {
+      "airflow_horizontal": {
+        "name": "Luchtstroom horizontaal",
+        "state": {
+          "center": "Midden",
+          "left": "Links",
+          "right": "Rechts",
+          "swing": "Heen en weer"
+        }
+      },
+      "airflow_vertical": {
+        "name": "Luchtstroom verticaal",
+        "state": {
+          "auto": "Automatisch",
+          "angle1": "Hoek 1",
+          "angle2": "Hoek 2",
+          "angle3": "Hoek 3",
+          "angle4": "Hoek 4",
+          "angle5": "Hoek 5",
+          "swing": "Heen en weer"
+        }
+      },
+      "program": {
+        "name": "Programma",
+        "state": {
+          "off": "Uit",
+          "program1": "Programma 1",
+          "program2": "Programma 2"
+        }
+      },
+      "dhw_operation_mode": {
+        "name": "{circuit} bedrijfsmodus",
+        "state": {
+          "off": "Uit",
+          "low": "Laag (Eco)",
+          "high": "Hoog (Comfort)",
+          "eco": "Eco+",
+          "ownprogram": "Eigen programma",
+          "manual": "Handmatig"
+        }
+      },
+      "dhw_current_temp": {
+        "name": "{circuit} temperatuurniveau",
+        "state": {
+          "off": "Uit",
+          "low": "Laag",
+          "high": "Hoog",
+          "eco": "Eco"
+        }
+      },
+      "hc_operation_mode": {
+        "name": "{circuit} bedrijfsmodus",
+        "state": {
+          "off": "Uit",
+          "manual": "Handmatig",
+          "auto": "Automatisch"
+        }
+      },
+      "hc_suwi_mode": {
+        "name": "{circuit} zomer/winter",
+        "state": {
+          "forced": "Geforceerd",
+          "off": "Uit",
+          "cooling": "Koelen"
+        }
+      },
+      "hc_heatcool_mode": {
+        "name": "{circuit} verwarmen/koelen",
+        "state": {
+          "heat": "Verwarmen",
+          "cool": "Koelen"
+        }
+      },
+      "holiday_mode": {
+        "name": "Vakantiemodus",
+        "state": {
+          "hm1": "Vakantiemodus 1",
+          "hm2": "Vakantiemodus 2",
+          "hm3": "Vakantiemodus 3",
+          "hm4": "Vakantiemodus 4",
+          "hm5": "Vakantiemodus 5",
+          "hm6": "Vakantiemodus 6",
+          "hm7": "Vakantiemodus 7",
+          "hm8": "Vakantiemodus 8"
+        }
+      },
+      "away_mode": {
+        "name": "Afwezigheidsmodus",
+        "state": {
+          "on": "Aan",
+          "off": "Uit"
+        }
+      },
+      "hc_night_switch_mode": {
+        "name": "{circuit} nachtschakelmodus"
+      },
+      "hc_control": {
+        "name": "{circuit} regeling"
+      },
+      "ventilation_summer_enable": {
+        "name": "{zone} zomerbypass",
+        "state": {
+          "no": "Uit",
+          "yes": "Aan"
+        }
+      },
+      "wb_charging_strategy": {
+        "name": "Laadstrategie",
+        "state": {
+          "default": "Standaard",
+          "solar-eco": "Solar-Eco"
+        }
+      }
+    },
+    "sensor": {
+      "hc": {
+        "name": "{circuit} status",
+        "state": {
+          "off": "Uit",
+          "manual": "Handmatig",
+          "auto": "Automatisch"
+        }
+      },
+      "indoor_humidity": {
+        "name": "Binnenluchtvochtigheid"
+      },
+      "flame_indication": {
+        "name": "Vlamindicatie"
+      },
+      "energy_history": {
+        "name": "Energiegeschiedenis"
+      },
+      "ventilation": {
+        "name": "{zone} niveau",
+        "state": {
+          "off": "Uit",
+          "min": "Niveau 1 (Minimaal)",
+          "red": "Niveau 2 (Verminderd)",
+          "nom": "Niveau 3 (Normaal)",
+          "max": "Niveau 4 (Maximaal)",
+          "dem": "Vraaggestuurd"
+        }
+      },
+      "wb_state": {
+        "name": "Wallbox Status",
+        "state": {
+          "available": "Available",
+          "authenticated": "Authenticated",
+          "preparing": "Awaiting Authorization",
+          "locked": "Locked",
+          "charging": "Charging",
+          "suspendedev": "Vehicle Paused",
+          "suspendedevse": "Wallbox Paused",
+          "init": "Initializing",
+          "faulted": "Faulted",
+          "limited": "Power Limited",
+          "phaseswitch": "Phase Switching"
+        }
+      },
+      "wb_power": {
+        "name": "Wallbox Vermogen"
+      },
+      "wb_energy_total": {
+        "name": "Wallbox Totale Energie"
+      },
+      "wb_temperature": {
+        "name": "Wallbox Temperatuur"
+      },
+      "wb_phases": {
+        "name": "Wallbox Fasen"
+      },
+      "wb_phase_sensor": {
+        "name": "Wallbox Fase"
+      },
+      "wb_chargelog": {
+        "name": "Wallbox Laadlogboek"
+      },
+      "thermostat_room_temp": {
+        "name": "Kamertemperatuur"
+      },
+      "thermostat_humidity": {
+        "name": "Kamervochtigheid"
+      },
+      "thermostat_setpoint": {
+        "name": "Kamer Instelpunt"
+      },
+      "thermostat_battery": {
+        "name": "Batterij"
+      },
+      "thermostat_signal": {
+        "name": "Signaalsterkte"
+      },
+      "dhw": {
+        "name": "{circuit} temperatuur"
+      },
+      "hs": {
+        "name": "Warmtebron"
+      },
+      "outdoor_temp": {
+        "name": "Buitentemperatuur"
+      },
+      "notifications": {
+        "name": "Meldingen"
+      },
+      "energy_history_hourly": {
+        "name": "Energiegeschiedenis (uurlijks)"
+      }
+    },
+    "binary_sensor": {
+      "wb_network": {
+        "name": "Wallbox Netwerk"
+      },
+      "thermostat_rf_status": {
+        "name": "RF Verbinding"
+      }
+    },
+    "number": {
+      "wb_price": {
+        "name": "Stroomprijs"
+      },
+      "wb_charge_limit": {
+        "name": "Laadlimiet"
+      },
+      "ventilation_summer_duration": {
+        "name": "Zomerbypass duur"
+      }
+    },
+    "button": {
+      "wb_authenticate": {
+        "name": "Laden authenticeren"
+      },
+      "wb_start_charging": {
+        "name": "Laden starten"
+      },
+      "wb_pause_charging": {
+        "name": "Laden pauzeren"
+      }
+    },
+    "switch": {
+      "child_lock": {
+        "name": "Kinderbeveiliging"
+      },
+      "wb_locked": {
+        "name": "Wallbox Vergrendeld"
+      },
+      "wb_auth": {
+        "name": "Wallbox Auth"
+      },
+      "wb_rfid_secure": {
+        "name": "Wallbox RFID Beveiligd"
+      },
+      "plasmacluster": {
+        "name": "Plasmacluster"
+      }
+    },
+    "water_heater": {
+      "dhw": {
+        "name": "Boiler {circuit}",
+        "state_attributes": {
+          "operation_mode": {
+            "state": {
+              "off": "Uit",
+              "low": "Laag (Eco)",
+              "high": "Hoog (Comfort)",
+              "eco": "Eco+",
+              "manual": "Handmatig",
+              "ownprogram": "Eigen programma"
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/custom_components/bosch_homecom/translations/nl.json
+++ b/custom_components/bosch_homecom/translations/nl.json
@@ -351,7 +351,7 @@
     },
     "water_heater": {
       "dhw": {
-        "name": "Boiler{circuit}",
+        "name": "Boiler {circuit}",
         "state_attributes": {
           "operation_mode": {
             "state": {

--- a/custom_components/bosch_homecom/translations/nl.json
+++ b/custom_components/bosch_homecom/translations/nl.json
@@ -318,7 +318,7 @@
         "name": "Laadlimiet"
       },
       "ventilation_summer_duration": {
-        "name": "Zomerbypass duur"
+        "name": "{zone} zomerbypass duur"
       }
     },
     "button": {

--- a/custom_components/bosch_homecom/translations/nl.json
+++ b/custom_components/bosch_homecom/translations/nl.json
@@ -351,7 +351,7 @@
     },
     "water_heater": {
       "dhw": {
-        "name": "Boiler",
+        "name": "Boiler {circuit}",
         "state_attributes": {
           "operation_mode": {
             "state": {

--- a/custom_components/bosch_homecom/translations/nl.json
+++ b/custom_components/bosch_homecom/translations/nl.json
@@ -351,7 +351,7 @@
     },
     "water_heater": {
       "dhw": {
-        "name": "Boiler {circuit}",
+        "name": "Boiler{circuit}",
         "state_attributes": {
           "operation_mode": {
             "state": {

--- a/custom_components/bosch_homecom/translations/nl.json
+++ b/custom_components/bosch_homecom/translations/nl.json
@@ -351,7 +351,7 @@
     },
     "water_heater": {
       "dhw": {
-        "name": "Boiler {circuit}",
+        "name": "Boiler",
         "state_attributes": {
           "operation_mode": {
             "state": {

--- a/custom_components/bosch_homecom/water_heater.py
+++ b/custom_components/bosch_homecom/water_heater.py
@@ -74,9 +74,9 @@ class BoschComK40WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         """Initialize water heater entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "dhw"
-        self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
+        self._attr_suggested_object_id = field + "_waterheater"
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._ioperation_map = {v: k for k, v in self._operation_map.items()}
@@ -142,12 +142,13 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         """Initialize water heater entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "dhw"
+        self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
+        self._attr_suggested_object_id = field + "_waterheater"
         self._coordinator = coordinator
         self._attr_should_poll = False
         self.field = field
-        self._attr_suggested_object_id = field + "_waterheater"
 
         self._attr_min_temp = 36
         self._attr_max_temp = 60

--- a/custom_components/bosch_homecom/water_heater.py
+++ b/custom_components/bosch_homecom/water_heater.py
@@ -15,6 +15,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .const import get_field_number
 from .coordinator import BoschComModuleCoordinatorK40, BoschComModuleCoordinatorWddw2
 
 
@@ -143,7 +144,7 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         """Initialize water heater entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "dhw"
-        self._attr_translation_placeholders = {"circuit": field}
+        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}"
         self._coordinator = coordinator

--- a/custom_components/bosch_homecom/water_heater.py
+++ b/custom_components/bosch_homecom/water_heater.py
@@ -77,6 +77,7 @@ class BoschComK40WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
+        self._attr_suggested_object_id = field + "_waterheater"
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._ioperation_map = {v: k for k, v in self._operation_map.items()}
@@ -142,12 +143,13 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         """Initialize water heater entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "dhw"
+        self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
+        self._attr_suggested_object_id = field + "_waterheater"
         self._coordinator = coordinator
         self._attr_should_poll = False
         self.field = field
-        self._attr_suggested_object_id = field + "_waterheater"
 
         self._attr_min_temp = 36
         self._attr_max_temp = 60

--- a/custom_components/bosch_homecom/water_heater.py
+++ b/custom_components/bosch_homecom/water_heater.py
@@ -74,7 +74,8 @@ class BoschComK40WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         """Initialize water heater entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "dhw"
-        self._attr_translation_placeholders = {"circuit": ""}
+        # The K40 API does not have a circuit identifier type "dhw1", instead it uses a generic and deixo or more specific name in translation with placeholder
+        self._attr_translation_placeholders = {"circuit": "dhw1"}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._attr_suggested_object_id = field + "_waterheater"
@@ -143,7 +144,7 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         """Initialize water heater entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "dhw"
-        self._attr_translation_placeholders = {"circuit": " " + field}
+        self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._attr_suggested_object_id = field + "_waterheater"

--- a/custom_components/bosch_homecom/water_heater.py
+++ b/custom_components/bosch_homecom/water_heater.py
@@ -15,7 +15,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import get_field_number
 from .coordinator import BoschComModuleCoordinatorK40, BoschComModuleCoordinatorWddw2
 
 
@@ -144,7 +143,7 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         """Initialize water heater entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "dhw"
-        self._attr_translation_placeholders = {"circuit": get_field_number(field)}
+        self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}"
         self._coordinator = coordinator

--- a/custom_components/bosch_homecom/water_heater.py
+++ b/custom_components/bosch_homecom/water_heater.py
@@ -77,7 +77,6 @@ class BoschComK40WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_suggested_object_id = field + "_waterheater"
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._ioperation_map = {v: k for k, v in self._operation_map.items()}
@@ -143,13 +142,12 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         """Initialize water heater entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "dhw"
-        self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
-        self._attr_suggested_object_id = field + "_waterheater"
         self._coordinator = coordinator
         self._attr_should_poll = False
         self.field = field
+        self._attr_suggested_object_id = field + "_waterheater"
 
         self._attr_min_temp = 36
         self._attr_max_temp = 60

--- a/custom_components/bosch_homecom/water_heater.py
+++ b/custom_components/bosch_homecom/water_heater.py
@@ -146,7 +146,6 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}"
-        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self.field = field

--- a/custom_components/bosch_homecom/water_heater.py
+++ b/custom_components/bosch_homecom/water_heater.py
@@ -53,7 +53,6 @@ class BoschComK40WaterHeater(CoordinatorEntity, WaterHeaterEntity):
     """Representation of a BoschComK40 water heater entity."""
 
     _attr_has_entity_name = True
-    _attr_name = None
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = WaterHeaterEntityFeature.OPERATION_MODE
     _attr_operation_list = ["Eco+", "Eco", "Comfort", "Program", "Off"]
@@ -74,10 +73,10 @@ class BoschComK40WaterHeater(CoordinatorEntity, WaterHeaterEntity):
     ) -> None:
         """Initialize water heater entity."""
         super().__init__(coordinator)
-        # self._attr_translation_key = "ac"
+        self._attr_translation_key = "dhw"
+        self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
-        self._attr_unique_id = f"{coordinator.unique_id}"
-        self._attr_name = field
+        self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._coordinator = coordinator
         self._attr_should_poll = False
         self._ioperation_map = {v: k for k, v in self._operation_map.items()}
@@ -143,9 +142,8 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         """Initialize water heater entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "dhw"
-        self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
-        self._attr_unique_id = f"{coordinator.unique_id}"
+        self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._coordinator = coordinator
         self._attr_should_poll = False
         self.field = field

--- a/custom_components/bosch_homecom/water_heater.py
+++ b/custom_components/bosch_homecom/water_heater.py
@@ -146,7 +146,7 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         self._attr_translation_placeholders = {"circuit": field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}"
-        self._attr_name = field + "_waterheater"
+        self._attr_name = None
         self._coordinator = coordinator
         self._attr_should_poll = False
         self.field = field

--- a/custom_components/bosch_homecom/water_heater.py
+++ b/custom_components/bosch_homecom/water_heater.py
@@ -74,6 +74,7 @@ class BoschComK40WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         """Initialize water heater entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "dhw"
+        self._attr_translation_placeholders = {"circuit": ""}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._attr_suggested_object_id = field + "_waterheater"
@@ -142,7 +143,7 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         """Initialize water heater entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "dhw"
-        self._attr_translation_placeholders = {"circuit": field}
+        self._attr_translation_placeholders = {"circuit": " " + field}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._attr_suggested_object_id = field + "_waterheater"

--- a/custom_components/bosch_homecom/water_heater.py
+++ b/custom_components/bosch_homecom/water_heater.py
@@ -149,6 +149,7 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         self._coordinator = coordinator
         self._attr_should_poll = False
         self.field = field
+        self._attr_suggested_object_id = field + "_waterheater"
 
         self._attr_min_temp = 36
         self._attr_max_temp = 60


### PR DESCRIPTION
Removed _attr_name attributes where a translation_key is set, because they overwrite the translation_key and prevents correct translation.