### PR TITLE
feat(wddw2): full TR4001 support — switches, improved water heater and notification sensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Local development journal — never goes into upstream PR
+PROGRESS.md
+
+# Claude Code memory (auto-generated, not for version control)
+memory/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/custom_components/bosch_homecom/const.py
+++ b/custom_components/bosch_homecom/const.py
@@ -102,3 +102,8 @@ BOSCH_SENSOR_DESCRIPTORS = {
         },
     ]
 }
+
+WDDW2_NOTIFICATION_CODES: dict[str, str] = {
+    "E01": "Hohe Temperatur",
+    "E07": "Luftblasen erkannt",
+}

--- a/custom_components/bosch_homecom/const.py
+++ b/custom_components/bosch_homecom/const.py
@@ -106,4 +106,5 @@ BOSCH_SENSOR_DESCRIPTORS = {
 WDDW2_NOTIFICATION_CODES: dict[str, str] = {
     "E01": "Hohe Temperatur",
     "E07": "Luftblasen erkannt",
+    "E13": "Ausfall der Wasserdurchflussmessung",
 }

--- a/custom_components/bosch_homecom/const.py
+++ b/custom_components/bosch_homecom/const.py
@@ -6,7 +6,15 @@ from datetime import timedelta
 from typing import Final
 
 from homeassistant.components.sensor import SensorDeviceClass
-from homeassistant.const import UnitOfTemperature, UnitOfVolumeFlowRate
+from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfTemperature,
+    UnitOfTime,
+    UnitOfVolume,
+    UnitOfVolumeFlowRate,
+)
 
 DOMAIN = "bosch_homecom"
 DEFAULT_UPDATE_INTERVAL: Final = timedelta(seconds=60)
@@ -106,6 +114,58 @@ BOSCH_SENSOR_DESCRIPTORS = {
             "unit": None,
             "state_class": "total_increasing",
             "entity_category": "diagnostic",
+        },
+        {
+            "key": "hs_actual_power",
+            "translation_key": "hs_actual_power",
+            "path": ["heat_sources", "actualPower"],
+            "name": "Power",
+            "device_class": SensorDeviceClass.POWER,
+            "unit": UnitOfPower.KILO_WATT,
+            "state_class": "measurement",
+            "scope": "device",
+        },
+        {
+            "key": "hs_power_percentage",
+            "translation_key": "hs_power_percentage",
+            "path": ["heat_sources", "powerPercentage"],
+            "name": "Power Percentage",
+            "device_class": None,
+            "unit": PERCENTAGE,
+            "state_class": "measurement",
+            "entity_category": "diagnostic",
+            "scope": "device",
+        },
+        {
+            "key": "hs_operation_hours",
+            "translation_key": "hs_operation_hours",
+            "path": ["heat_sources", "operationHours"],
+            "name": "Operation Hours",
+            "device_class": None,
+            "unit": UnitOfTime.HOURS,
+            "state_class": "total_increasing",
+            "entity_category": "diagnostic",
+            "scope": "device",
+        },
+        {
+            "key": "hs_electricity_total",
+            "translation_key": "hs_electricity_total",
+            "path": ["heat_sources", "electricityTotalConsumption"],
+            "name": "Electricity Consumption",
+            "device_class": SensorDeviceClass.ENERGY,
+            "unit": UnitOfEnergy.KILO_WATT_HOUR,
+            "state_class": "total_increasing",
+            "scope": "device",
+        },
+        {
+            "key": "water_total_consumption",
+            "translation_key": "water_total_consumption",
+            "path": ["water_total_consumption"],
+            "name": "Water Consumption",
+            "device_class": SensorDeviceClass.WATER,
+            "unit": UnitOfVolume.LITERS,
+            "state_class": "total_increasing",
+            "scope": "device",
         },
     ]
 }

--- a/custom_components/bosch_homecom/const.py
+++ b/custom_components/bosch_homecom/const.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from typing import Final
 
 from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import UnitOfTemperature, UnitOfVolumeFlowRate
 
 DOMAIN = "bosch_homecom"
 DEFAULT_UPDATE_INTERVAL: Final = timedelta(seconds=60)
@@ -53,52 +54,58 @@ BOSCH_SENSOR_DESCRIPTORS = {
     "wddw2": [
         {
             "key": "operation_mode",
+            "translation_key": "dhw_operation_mode",
             "path": ["dhw_circuits", "dhw1", "operationMode"],
-            "name": "DHW Operation Mode",
+            "name": "Operation Mode",
             "device_class": None,
             "unit": None,
             "state_class": None,
         },
         {
             "key": "air_box_temperature",
+            "translation_key": "dhw_air_box_temperature",
             "path": ["dhw_circuits", "dhw1", "airBoxTemperature"],
             "name": "Air Box Temperature",
             "device_class": SensorDeviceClass.TEMPERATURE,
-            "unit": None,
+            "unit": UnitOfTemperature.CELSIUS,
             "state_class": "measurement",
         },
         {
             "key": "inlet_temperature",
+            "translation_key": "dhw_inlet_temperature",
             "path": ["dhw_circuits", "dhw1", "inletTemperature"],
-            "name": "DHW Inlet Temperature",
+            "name": "Inlet Temperature",
             "device_class": SensorDeviceClass.TEMPERATURE,
-            "unit": None,
+            "unit": UnitOfTemperature.CELSIUS,
             "state_class": "measurement",
         },
         {
             "key": "outlet_temperature",
+            "translation_key": "dhw_outlet_temperature",
             "path": ["dhw_circuits", "dhw1", "outletTemperature"],
-            "name": "DHW Outlet Temperature",
+            "name": "Outlet Temperature",
             "device_class": SensorDeviceClass.TEMPERATURE,
-            "unit": None,
+            "unit": UnitOfTemperature.CELSIUS,
             "state_class": "measurement",
         },
         {
             "key": "water_flow",
+            "translation_key": "dhw_water_flow",
             "path": ["dhw_circuits", "dhw1", "waterFlow"],
-            "name": "DHW Water Flow",
+            "name": "Water Flow",
             "device_class": None,
-            "unit": None,  # a API já devolve "l/min" na unidade do nó
+            "unit": UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
             "state_class": "measurement",
         },
-        # No WDDW2 o contador de arranques vem como nbStarts dentro do dhw1
         {
             "key": "heat_source_starts",
+            "translation_key": "dhw_heat_source_starts",
             "path": ["dhw_circuits", "dhw1", "nbStarts"],
             "name": "Heat Source Starts",
             "device_class": None,
             "unit": None,
             "state_class": "total_increasing",
+            "entity_category": "diagnostic",
         },
     ]
 }

--- a/custom_components/bosch_homecom/coordinator.py
+++ b/custom_components/bosch_homecom/coordinator.py
@@ -173,6 +173,43 @@ class BoschComModuleCoordinatorK40(BoschComModuleCoordinatorBase[BHCDeviceK40]):
 class BoschComModuleCoordinatorWddw2(BoschComModuleCoordinatorBase[BHCDeviceWddw2]):
     """A coordinator to manage the fetching of BoschCom data."""
 
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize wddw2 coordinator with extra state attributes."""
+        super().__init__(*args, **kwargs)
+        self.wddw2_safety_temperature: str | None = None
+        self.wddw2_holiday_mode: str | None = None
+        self.wddw2_temp_levels: dict[str, float] = {}
+
+    async def _async_update_data(self) -> BHCDeviceWddw2:
+        """Update data and additionally fetch wddw2-specific switch states."""
+        data = await super()._async_update_data()
+        try:
+            result = await self.bhc.async_action_universal_get(
+                self.unique_id, "/resource/dhwCircuits/dhw1/safetyTemperature"
+            )
+            self.wddw2_safety_temperature = (result or {}).get("value")
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            result = await self.bhc.async_action_universal_get(
+                self.unique_id, "/resource/system/holidayMode"
+            )
+            self.wddw2_holiday_mode = (result or {}).get("value")
+        except Exception:  # noqa: BLE001
+            pass
+        for mode, path in (
+            ("manual", "/resource/dhwCircuits/dhw1/manualsetpoint"),
+            ("bath", "/resource/dhwCircuits/dhw1/temperatureLevels/bath"),
+        ):
+            try:
+                result = await self.bhc.async_action_universal_get(self.unique_id, path)
+                value = (result or {}).get("value")
+                if isinstance(value, (int, float)):
+                    self.wddw2_temp_levels[mode] = float(value)
+            except Exception:  # noqa: BLE001
+                pass
+        return data
+
     def _build_device_data(self, data: BHCDeviceWddw2) -> BHCDeviceWddw2:
         """Build WDDW2 device data."""
         return BHCDeviceWddw2(

--- a/custom_components/bosch_homecom/icons.json
+++ b/custom_components/bosch_homecom/icons.json
@@ -19,6 +19,24 @@
         }
       },
       "sensor": {
+        "dhw_operation_mode": {
+          "default": "mdi:shower-head"
+        },
+        "dhw_water_flow": {
+          "default": "mdi:waves"
+        },
+        "dhw_heating_active": {
+          "default": "mdi:heating-coil"
+        },
+        "dhw_heat_source_starts": {
+          "default": "mdi:counter"
+        },
+        "hs_operation_hours": {
+          "default": "mdi:timer-sand"
+        },
+        "hs_power_percentage": {
+          "default": "mdi:flash"
+        },
         "wb_state": {
           "default": "mdi:ev-station"
         },

--- a/custom_components/bosch_homecom/icons.json
+++ b/custom_components/bosch_homecom/icons.json
@@ -61,6 +61,12 @@
         },
         "wb_rfid_secure": {
           "default": "mdi:card-account-details"
+        },
+        "dhw_safety_temperature": {
+          "default": "mdi:thermometer-alert"
+        },
+        "dhw_holiday_mode": {
+          "default": "mdi:palm-tree"
         }
       },
       "text": {

--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -230,6 +230,27 @@ async def async_setup_entry(
                 }
 
                 for desc in wddw2_desc:
+                    if desc.get("scope") == "device":
+                        unique_suffix = f"device-{desc['key']}"
+                        try:
+                            entities.append(
+                                BoschComGenericSensor(
+                                    coordinator=coordinator,
+                                    name=desc["name"],
+                                    unique_suffix=unique_suffix,
+                                    path=desc.get("path", []),
+                                    unit=desc.get("unit"),
+                                    device_class=desc.get("device_class"),
+                                    state_class=desc.get("state_class"),
+                                    translation_key=desc.get("translation_key"),
+                                    entity_category=desc.get("entity_category"),
+                                )
+                            )
+                        except Exception:  # keep onboarding even if one fails
+                            _LOGGER.debug(
+                                "Failed to add generic sensor %s", unique_suffix
+                            )
+                        continue
                     for dhw_id in dhw_ids:
                         last_key = desc.get("path", [""])[-1]
                         dhw = dhw_by_id.get(dhw_id) if dhw_id else None

--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -29,7 +29,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import BOSCH_SENSOR_DESCRIPTORS
+from .const import BOSCH_SENSOR_DESCRIPTORS, WDDW2_NOTIFICATION_CODES
 from .coordinator import (
     BoschComModuleCoordinatorCommodule,
     BoschComModuleCoordinatorIcom,
@@ -476,7 +476,12 @@ class BoschComSensorNotificationsK40(BoschComSensorBase):
 
 
 class BoschComSensorNotificationsWddw2(BoschComSensorBase):
-    """BoschComSensor notifications."""
+    """BoschComSensor notifications for wddw2 devices.
+
+    Filters historical entries (act == 'H') from active state.
+    Human-readable descriptions are provided via WDDW2_NOTIFICATION_CODES.
+    Full history including historical entries is exposed in extra_state_attributes.
+    """
 
     _attr_has_entity_name = True
 
@@ -505,12 +510,34 @@ class BoschComSensorNotificationsWddw2(BoschComSensorBase):
 
     @property
     def state(self):
-        """Return Notifications."""
+        """Return active (non-historical) notifications as a newline-joined string."""
+        active = [
+            item
+            for item in (self.coordinator.data.notifications or [])
+            if "dcd" in item and item.get("act") != "H"
+        ]
+        if not active:
+            return "none"
         return "\n".join(
-            f"{item['dcd']}-{item['ccd']}"
-            for item in self.coordinator.data.notifications
-            if "dcd" in item and "ccd" in item
+            WDDW2_NOTIFICATION_CODES.get(item["dcd"].strip(), item["dcd"].strip())
+            for item in active
         )
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Expose full notification history including historical entries."""
+        verlauf = [
+            {
+                "code": item.get("dcd", "").strip(),
+                "beschreibung": WDDW2_NOTIFICATION_CODES.get(
+                    item.get("dcd", "").strip(), item.get("dcd", "").strip()
+                ),
+                "status": "historisch" if item.get("act") == "H" else "aktiv",
+            }
+            for item in (self.coordinator.data.notifications or [])
+            if "dcd" in item
+        ]
+        return {"verlauf": verlauf} if verlauf else {}
 
 
 class BoschComSensorDhw(BoschComSensorBase):

--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -212,37 +212,29 @@ async def async_setup_entry(
             for sensor in _build_rrc2_sensors(coordinator, config_entry):
                 entities.append(sensor)
 
-        # ---- WDDW2 (existing DHW sensor + NEW generic + NEW derived) ----
+        # ---- WDDW2 ----
         elif device_type == "wddw2":
-            # Existing per-circuit DHW sensor
-            for ref in coordinator.data.dhw_circuits:
-                dhw_id = ref["id"].split("/")[-1]
-                if re.fullmatch(r"dhw\d", dhw_id):
-                    entities.append(
-                        BoschComSensorDhwWddw2(
-                            coordinator=coordinator,
-                            config_entry=config_entry,
-                            field=dhw_id,
-                        )
-                    )
-
-            # Issue #129: surface heat-source + water totals (top-level paths).
-            entities.extend(_build_wddw2_totals_sensors(coordinator))
-
-            # NEW: generic sensors from descriptors (BOSCH_SENSOR_DESCRIPTORS["wddw2"])
+            # Generic sensors from descriptors (BOSCH_SENSOR_DESCRIPTORS["wddw2"])
             wddw2_desc = BOSCH_SENSOR_DESCRIPTORS.get("wddw2", [])
             if wddw2_desc:
-                # If descriptors are per-circuit, try to expand per each dhwX
                 dhw_ids = [
                     ref["id"].split("/")[-1]
                     for ref in coordinator.data.dhw_circuits
                     if re.fullmatch(r"dhw\d", ref["id"].split("/")[-1])
-                ] or [
-                    None
-                ]  # fallback to single set if not per circuit
+                ] or [None]
+
+                dhw_by_id = {
+                    ref["id"].split("/")[-1]: ref
+                    for ref in coordinator.data.dhw_circuits
+                    if re.fullmatch(r"dhw\d", ref["id"].split("/")[-1])
+                }
 
                 for desc in wddw2_desc:
                     for dhw_id in dhw_ids:
+                        last_key = desc.get("path", [""])[-1]
+                        dhw = dhw_by_id.get(dhw_id) if dhw_id else None
+                        if dhw is not None and dhw.get(last_key) is None:
+                            continue
                         path = desc.get("path", [])
                         resolved_path = _resolve_path(path, dhw_id)
                         unique_suffix = (
@@ -254,16 +246,14 @@ async def async_setup_entry(
                             entities.append(
                                 BoschComGenericSensor(
                                     coordinator=coordinator,
-                                    name=(
-                                        desc["name"]
-                                        if not dhw_id
-                                        else f"{desc['name']} {dhw_id.upper()}"
-                                    ),
+                                    name=desc["name"],
                                     unique_suffix=unique_suffix,
                                     path=resolved_path,
                                     unit=desc.get("unit"),
                                     device_class=desc.get("device_class"),
                                     state_class=desc.get("state_class"),
+                                    translation_key=desc.get("translation_key"),
+                                    entity_category=desc.get("entity_category"),
                                 )
                             )
                         except Exception:  # keep onboarding even if one fails
@@ -271,7 +261,6 @@ async def async_setup_entry(
                                 "Failed to add generic sensor %s", unique_suffix
                             )
 
-            # NEW: derived sensors (single set; adjust to per-circuit if precisares)
             try:
                 entities.append(
                     BoschComDerivedDeltaTSensor(
@@ -497,7 +486,8 @@ class BoschComSensorNotificationsWddw2(BoschComSensorBase):
             unique_id=f"{coordinator.unique_id}-notifications",
             icon="mdi:bell",
         )
-        self._attr_translation_key = "notifications"
+        self._attr_translation_key = "dhw_notifications"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_unique_id = f"{coordinator.unique_id}-notifications"
         self._attr_suggested_object_id = "notifications"
         self._attr_should_poll = False
@@ -533,6 +523,7 @@ class BoschComSensorNotificationsWddw2(BoschComSensorBase):
                     item.get("dcd", "").strip(), item.get("dcd", "").strip()
                 ),
                 "status": "historisch" if item.get("act") == "H" else "aktiv",
+                "schwere": "Störung" if item.get("fc") == "8" else "Warnung",
             }
             for item in (self.coordinator.data.notifications or [])
             if "dcd" in item
@@ -1139,8 +1130,8 @@ class BoschComSensorDhwWddw2(BoschComSensorBase):
             icon="mdi:water-boiler",
         )
         self._attr_translation_key = "dhw"
-        self._attr_translation_placeholders = {"circuit": field}
-        self._attr_unique_id = f"{coordinator.unique_id}-{field}"
+        self._attr_translation_placeholders = {"circuit": re.sub(r"\D", "", field)}
+        self._attr_unique_id = f"{coordinator.unique_id}-{field}-sensor"
         self._attr_suggested_object_id = field + "_sensor"
         self._attr_should_poll = False
         self.field = field
@@ -1284,17 +1275,22 @@ class BoschComGenericSensor(CoordinatorEntity, SensorEntity):
         unit,
         device_class,
         state_class: Optional[str],
+        translation_key: Optional[str] = None,
+        entity_category: Optional[str] = None,
     ):
         super().__init__(coordinator)
         self._attr_has_entity_name = True
-        self._attr_name = name
         self._attr_unique_id = f"{coordinator.unique_id}-{unique_suffix}"
         self._declared_unit = unit
         self._attr_device_class = device_class
         self._attr_state_class = state_class
         self._resolver = DynamicPathResolver(path)
         self._attr_device_info = coordinator.device_info
-        self._attr_entity_category = None  # or EntityCategory.DIAGNOSTIC if you prefer
+        self._attr_entity_category = EntityCategory(entity_category) if entity_category else None
+        if translation_key:
+            self._attr_translation_key = translation_key
+        else:
+            self._attr_name = name
 
     def _coordinator_data_as_dict(self) -> dict:
         data = getattr(self.coordinator, "data", {}) or {}
@@ -1332,7 +1328,7 @@ class BoschComDerivedDeltaTSensor(CoordinatorEntity, SensorEntity):
     def __init__(self, coordinator, name: str, unique_suffix: str):
         super().__init__(coordinator)
         self._attr_has_entity_name = True
-        self._attr_name = name
+        self._attr_translation_key = "dhw_delta_t"
         self._attr_unique_id = f"{coordinator.unique_id}-{unique_suffix}"
         self._attr_device_info = coordinator.device_info
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
@@ -1428,11 +1424,10 @@ class BoschComHeatingActiveBinarySensor(CoordinatorEntity, BinarySensorEntity):
     ):
         super().__init__(coordinator)
         self._attr_has_entity_name = True
-        self._attr_name = name
+        self._attr_translation_key = "dhw_heating_active"
         self._attr_unique_id = f"{coordinator.unique_id}-{unique_suffix}"
         self._attr_device_info = coordinator.device_info
         self._delta_t_threshold = delta_t_threshold
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/bosch_homecom/strings.json
+++ b/custom_components/bosch_homecom/strings.json
@@ -301,6 +301,40 @@
       },
       "energy_history_hourly": {
         "name": "Energy history (hourly)"
+      },
+      "dhw_operation_mode": {
+        "name": "Operation Mode",
+        "state": {
+          "manual": "Manual",
+          "bath": "Safety Temperature"
+        }
+      },
+      "dhw_air_box_temperature": {
+        "name": "Air Box Temperature"
+      },
+      "dhw_inlet_temperature": {
+        "name": "Inlet Temperature"
+      },
+      "dhw_outlet_temperature": {
+        "name": "Outlet Temperature"
+      },
+      "dhw_water_flow": {
+        "name": "Water Flow"
+      },
+      "dhw_heat_source_starts": {
+        "name": "Heat Source Starts"
+      },
+      "dhw_delta_t": {
+        "name": "Temperature Difference"
+      },
+      "dhw_notifications": {
+        "name": "Notifications",
+        "state": {
+          "none": "None"
+        }
+      },
+      "dhw_heating_active": {
+        "name": "Water Heating"
       }
     },
     "binary_sensor": {

--- a/custom_components/bosch_homecom/strings.json
+++ b/custom_components/bosch_homecom/strings.json
@@ -335,6 +335,23 @@
       },
       "dhw_heating_active": {
         "name": "Water Heating"
+      },
+      "hs_actual_power": {
+        "name": "Power"
+      },
+      "hs_power_percentage": {
+        "name": "Power Percentage"
+      },
+      "hs_operation_hours": {
+        "name": "Operation Hours"
+      },
+      "hs_electricity_total": {
+        "name": "Electricity Consumption",
+        "description": "Estimated value calculated from installation date. Can be reset via the device display menu."
+      },
+      "water_total_consumption": {
+        "name": "Water Consumption",
+        "description": "Estimated value calculated from installation date. Can be reset via the device display menu."
       }
     },
     "binary_sensor": {

--- a/custom_components/bosch_homecom/strings.json
+++ b/custom_components/bosch_homecom/strings.json
@@ -348,6 +348,12 @@
       },
       "plasmacluster": {
         "name": "Plasmacluster"
+      },
+      "dhw_safety_temperature": {
+        "name": "Safety Temperature"
+      },
+      "dhw_holiday_mode": {
+        "name": "Holiday Mode"
       }
     },
     "water_heater": {

--- a/custom_components/bosch_homecom/strings.json
+++ b/custom_components/bosch_homecom/strings.json
@@ -422,6 +422,21 @@
             }
           }
         }
+      },
+      "dhw_wddw2": {
+        "name": "Water heater",
+        "state_attributes": {
+          "operation_mode": {
+            "state": {
+              "off": "Off",
+              "low": "Low (Eco)",
+              "high": "High (Comfort)",
+              "eco": "Eco+",
+              "manual": "Manual",
+              "ownprogram": "Own program"
+            }
+          }
+        }
       }
     }
   }

--- a/custom_components/bosch_homecom/switch.py
+++ b/custom_components/bosch_homecom/switch.py
@@ -1,5 +1,7 @@
 """Bosch HomeCom Custom Component."""
 
+from __future__ import annotations
+
 from typing import Any
 
 from homeassistant import config_entries, core

--- a/custom_components/bosch_homecom/switch.py
+++ b/custom_components/bosch_homecom/switch.py
@@ -7,12 +7,14 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homecom_alt.const import BOSCHCOM_DOMAIN, BOSCHCOM_ENDPOINT_GATEWAYS
 
 from .coordinator import (
     BoschComModuleCoordinatorCommodule,
     BoschComModuleCoordinatorK40,
     BoschComModuleCoordinatorRac,
     BoschComModuleCoordinatorRrc2,
+    BoschComModuleCoordinatorWddw2,
 )
 
 PARALLEL_UPDATES = 1
@@ -64,6 +66,12 @@ async def async_setup_entry(
     for coordinator in coordinators:
         if coordinator.data.device["deviceType"] == "rrc2":
             entities.extend(_build_rrc2_switches(coordinator))
+    for coordinator in coordinators:
+        if coordinator.data.device["deviceType"] == "wddw2":
+            if coordinator.wddw2_safety_temperature is not None:
+                entities.append(BoschComWddw2SafetyTempSwitch(coordinator=coordinator))
+            if coordinator.wddw2_holiday_mode is not None:
+                entities.append(BoschComWddw2HolidayModeSwitch(coordinator=coordinator))
     async_add_entities(entities)
 
 
@@ -489,3 +497,92 @@ def _build_rrc2_switches(
             )
 
     return entities
+
+
+class _BoschComWddw2SwitchBase(CoordinatorEntity, SwitchEntity):
+    """Base class for wddw2 on/off switches backed by a /resource path."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _resource_path: str = ""
+
+    def __init__(
+        self,
+        coordinator: BoschComModuleCoordinatorWddw2,
+        unique_suffix: str,
+        translation_key: str,
+    ) -> None:
+        """Initialize wddw2 switch."""
+        super().__init__(coordinator)
+        self._coordinator = coordinator
+        self._attr_translation_key = translation_key
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = f"{coordinator.unique_id}-{unique_suffix}"
+
+    def _get_current_value(self) -> str | None:
+        """Return the cached value from coordinator; subclasses override."""
+        return None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True when the switch value is 'on'."""
+        value = self._get_current_value()
+        if value is None:
+            return None
+        return value == "on"
+
+    async def _async_put(self, value: str) -> None:
+        """Send PUT request to the resource path."""
+        device_id = self._coordinator.unique_id
+        url = (
+            BOSCHCOM_DOMAIN
+            + BOSCHCOM_ENDPOINT_GATEWAYS
+            + device_id
+            + self._resource_path
+        )
+        await self._coordinator.bhc._async_http_request(
+            "put", url, {"value": value}, 1
+        )  # noqa: SLF001
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on."""
+        await self._async_put("on")
+        await self._coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off."""
+        await self._async_put("off")
+        await self._coordinator.async_request_refresh()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        value = self._get_current_value()
+        self._attr_is_on = (value == "on") if value is not None else None
+        self.async_write_ha_state()
+
+
+class BoschComWddw2SafetyTempSwitch(_BoschComWddw2SwitchBase):
+    """Switch for wddw2 safety temperature (bath mode) on/off."""
+
+    _resource_path = "/resource/dhwCircuits/dhw1/safetyTemperature"
+
+    def __init__(self, coordinator: BoschComModuleCoordinatorWddw2) -> None:
+        """Initialize safety temperature switch."""
+        super().__init__(coordinator, "safety-temperature", "dhw_safety_temperature")
+
+    def _get_current_value(self) -> str | None:
+        return self._coordinator.wddw2_safety_temperature
+
+
+class BoschComWddw2HolidayModeSwitch(_BoschComWddw2SwitchBase):
+    """Switch for wddw2 holiday mode on/off."""
+
+    _resource_path = "/resource/system/holidayMode"
+
+    def __init__(self, coordinator: BoschComModuleCoordinatorWddw2) -> None:
+        """Initialize holiday mode switch."""
+        super().__init__(coordinator, "holiday-mode", "dhw_holiday_mode")
+
+    def _get_current_value(self) -> str | None:
+        return self._coordinator.wddw2_holiday_mode

--- a/custom_components/bosch_homecom/switch.py
+++ b/custom_components/bosch_homecom/switch.py
@@ -542,9 +542,10 @@ class _BoschComWddw2SwitchBase(CoordinatorEntity, SwitchEntity):
             + device_id
             + self._resource_path
         )
-        await self._coordinator.bhc._async_http_request(
+        await self._coordinator.bhc.get_token()  # noqa: SLF001
+        await self._coordinator.bhc._async_http_request(  # noqa: SLF001
             "put", url, {"value": value}, 1
-        )  # noqa: SLF001
+        )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on."""

--- a/custom_components/bosch_homecom/translations/de.json
+++ b/custom_components/bosch_homecom/translations/de.json
@@ -349,6 +349,12 @@
       },
       "plasmacluster": {
         "name": "Plasmacluster"
+      },
+      "dhw_safety_temperature": {
+        "name": "Sicherheitstemperatur"
+      },
+      "dhw_holiday_mode": {
+        "name": "Urlaubsmodus"
       }
     },
     "water_heater": {

--- a/custom_components/bosch_homecom/translations/de.json
+++ b/custom_components/bosch_homecom/translations/de.json
@@ -423,6 +423,21 @@
             }
           }
         }
+      },
+      "dhw_wddw2": {
+        "name": "Warmwasser",
+        "state_attributes": {
+          "operation_mode": {
+            "state": {
+              "off": "Aus",
+              "low": "Niedrig (Eco)",
+              "high": "Hoch (Komfort)",
+              "eco": "Eco+",
+              "manual": "Manuell",
+              "ownprogram": "Eigenes Programm"
+            }
+          }
+        }
       }
     }
   }

--- a/custom_components/bosch_homecom/translations/de.json
+++ b/custom_components/bosch_homecom/translations/de.json
@@ -302,6 +302,40 @@
       },
       "energy_history_hourly": {
         "name": "Energieverlauf (stündlich)"
+      },
+      "dhw_operation_mode": {
+        "name": "Betriebsmodus",
+        "state": {
+          "manual": "Manuell",
+          "bath": "Sicherheitstemperatur"
+        }
+      },
+      "dhw_air_box_temperature": {
+        "name": "Lufttemperatur (Box)"
+      },
+      "dhw_inlet_temperature": {
+        "name": "Eingangstemperatur"
+      },
+      "dhw_outlet_temperature": {
+        "name": "Ausgangstemperatur"
+      },
+      "dhw_water_flow": {
+        "name": "Wasserdurchfluss"
+      },
+      "dhw_heat_source_starts": {
+        "name": "Betriebszyklen"
+      },
+      "dhw_delta_t": {
+        "name": "Temperaturdifferenz"
+      },
+      "dhw_notifications": {
+        "name": "Benachrichtigungen",
+        "state": {
+          "none": "Keine"
+        }
+      },
+      "dhw_heating_active": {
+        "name": "Wassererwärmung"
       }
     },
     "binary_sensor": {

--- a/custom_components/bosch_homecom/translations/de.json
+++ b/custom_components/bosch_homecom/translations/de.json
@@ -336,6 +336,23 @@
       },
       "dhw_heating_active": {
         "name": "Wassererwärmung"
+      },
+      "hs_actual_power": {
+        "name": "Leistung"
+      },
+      "hs_power_percentage": {
+        "name": "Leistung (%)"
+      },
+      "hs_operation_hours": {
+        "name": "Betriebsstunden"
+      },
+      "hs_electricity_total": {
+        "name": "Stromverbrauch",
+        "description": "Schätzwert ab Installationsdatum. Kann im Anzeigemenü des Geräts zurückgesetzt werden."
+      },
+      "water_total_consumption": {
+        "name": "Wasserverbrauch",
+        "description": "Schätzwert ab Installationsdatum. Kann im Anzeigemenü des Geräts zurückgesetzt werden."
       }
     },
     "binary_sensor": {

--- a/custom_components/bosch_homecom/translations/en.json
+++ b/custom_components/bosch_homecom/translations/en.json
@@ -300,6 +300,40 @@
       },
       "energy_history_hourly": {
         "name": "Energy history (hourly)"
+      },
+      "dhw_operation_mode": {
+        "name": "Operation Mode",
+        "state": {
+          "manual": "Manual",
+          "bath": "Safety Temperature"
+        }
+      },
+      "dhw_air_box_temperature": {
+        "name": "Air Box Temperature"
+      },
+      "dhw_inlet_temperature": {
+        "name": "Inlet Temperature"
+      },
+      "dhw_outlet_temperature": {
+        "name": "Outlet Temperature"
+      },
+      "dhw_water_flow": {
+        "name": "Water Flow"
+      },
+      "dhw_heat_source_starts": {
+        "name": "Heat Source Starts"
+      },
+      "dhw_delta_t": {
+        "name": "Temperature Difference"
+      },
+      "dhw_notifications": {
+        "name": "Notifications",
+        "state": {
+          "none": "None"
+        }
+      },
+      "dhw_heating_active": {
+        "name": "Water Heating"
       }
     },
     "binary_sensor": {

--- a/custom_components/bosch_homecom/translations/en.json
+++ b/custom_components/bosch_homecom/translations/en.json
@@ -334,6 +334,23 @@
       },
       "dhw_heating_active": {
         "name": "Water Heating"
+      },
+      "hs_actual_power": {
+        "name": "Power"
+      },
+      "hs_power_percentage": {
+        "name": "Power Percentage"
+      },
+      "hs_operation_hours": {
+        "name": "Operation Hours"
+      },
+      "hs_electricity_total": {
+        "name": "Electricity Consumption",
+        "description": "Estimated value calculated from installation date. Can be reset via the device display menu."
+      },
+      "water_total_consumption": {
+        "name": "Water Consumption",
+        "description": "Estimated value calculated from installation date. Can be reset via the device display menu."
       }
     },
     "binary_sensor": {

--- a/custom_components/bosch_homecom/translations/en.json
+++ b/custom_components/bosch_homecom/translations/en.json
@@ -421,6 +421,21 @@
             }
           }
         }
+      },
+      "dhw_wddw2": {
+        "name": "Water heater",
+        "state_attributes": {
+          "operation_mode": {
+            "state": {
+              "off": "Off",
+              "low": "Low (Eco)",
+              "high": "High (Comfort)",
+              "eco": "Eco+",
+              "manual": "Manual",
+              "ownprogram": "Own program"
+            }
+          }
+        }
       }
     }
   }

--- a/custom_components/bosch_homecom/translations/en.json
+++ b/custom_components/bosch_homecom/translations/en.json
@@ -347,6 +347,12 @@
       },
       "plasmacluster": {
         "name": "Plasmacluster"
+      },
+      "dhw_safety_temperature": {
+        "name": "Safety Temperature"
+      },
+      "dhw_holiday_mode": {
+        "name": "Holiday Mode"
       }
     },
     "water_heater": {

--- a/custom_components/bosch_homecom/translations/nl.json
+++ b/custom_components/bosch_homecom/translations/nl.json
@@ -421,6 +421,21 @@
             }
           }
         }
+      },
+      "dhw_wddw2": {
+        "name": "Boiler",
+        "state_attributes": {
+          "operation_mode": {
+            "state": {
+              "off": "Uit",
+              "low": "Laag (Eco)",
+              "high": "Hoog (Comfort)",
+              "eco": "Eco+",
+              "manual": "Handmatig",
+              "ownprogram": "Eigen programma"
+            }
+          }
+        }
       }
     }
   }

--- a/custom_components/bosch_homecom/translations/nl.json
+++ b/custom_components/bosch_homecom/translations/nl.json
@@ -300,6 +300,40 @@
       },
       "energy_history_hourly": {
         "name": "Energiegeschiedenis (uurlijks)"
+      },
+      "dhw_operation_mode": {
+        "name": "Bedrijfsmodus",
+        "state": {
+          "manual": "Handmatig",
+          "bath": "Veiligheidstemperatuur"
+        }
+      },
+      "dhw_air_box_temperature": {
+        "name": "Luchttemperatuur (Box)"
+      },
+      "dhw_inlet_temperature": {
+        "name": "Ingangstemperatuur"
+      },
+      "dhw_outlet_temperature": {
+        "name": "Uitgangstemperatuur"
+      },
+      "dhw_water_flow": {
+        "name": "Waterstroom"
+      },
+      "dhw_heat_source_starts": {
+        "name": "Bedrijfscycli"
+      },
+      "dhw_delta_t": {
+        "name": "Temperatuurverschil"
+      },
+      "dhw_notifications": {
+        "name": "Meldingen",
+        "state": {
+          "none": "Geen"
+        }
+      },
+      "dhw_heating_active": {
+        "name": "Waterverwarming"
       }
     },
     "binary_sensor": {
@@ -347,6 +381,12 @@
       },
       "plasmacluster": {
         "name": "Plasmacluster"
+      },
+      "dhw_safety_temperature": {
+        "name": "Veiligheidstemperatuur"
+      },
+      "dhw_holiday_mode": {
+        "name": "Vakantiestand"
       }
     },
     "water_heater": {

--- a/custom_components/bosch_homecom/translations/nl.json
+++ b/custom_components/bosch_homecom/translations/nl.json
@@ -334,6 +334,23 @@
       },
       "dhw_heating_active": {
         "name": "Waterverwarming"
+      },
+      "hs_actual_power": {
+        "name": "Vermogen"
+      },
+      "hs_power_percentage": {
+        "name": "Vermogen (%)"
+      },
+      "hs_operation_hours": {
+        "name": "Bedrijfsuren"
+      },
+      "hs_electricity_total": {
+        "name": "Stroomverbruik",
+        "description": "Geschatte waarde berekend vanaf installatiedatum. Kan worden gereset via het displaymenu van het apparaat."
+      },
+      "water_total_consumption": {
+        "name": "Waterverbruik",
+        "description": "Geschatte waarde berekend vanaf installatiedatum. Kan worden gereset via het displaymenu van het apparaat."
       }
     },
     "binary_sensor": {

--- a/custom_components/bosch_homecom/water_heater.py
+++ b/custom_components/bosch_homecom/water_heater.py
@@ -186,8 +186,7 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
     ) -> None:
         """Initialize water heater entity."""
         super().__init__(coordinator)
-        self._attr_translation_key = "dhw"
-        self._attr_translation_placeholders = {"circuit": re.sub(r"\D", "", field)}
+        self._attr_translation_key = "dhw_wddw2"
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._attr_suggested_object_id = field + "_waterheater"

--- a/custom_components/bosch_homecom/water_heater.py
+++ b/custom_components/bosch_homecom/water_heater.py
@@ -20,6 +20,19 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import BoschComModuleCoordinatorK40, BoschComModuleCoordinatorWddw2
 
+PARALLEL_UPDATES = 1
+
+_WDDW2_OP_MODE_DISPLAY: dict[str, dict[str, str]] = {
+    "de": {"manual": "Manuell", "bath": "Sicherheitstemperatur"},
+    "en": {"manual": "Manual", "bath": "Safety Temperature"},
+}
+
+
+def _translate_op_mode(lang: str, mode: str) -> str:
+    """Return a human-readable label for a wddw2 operation mode."""
+    table = _WDDW2_OP_MODE_DISPLAY.get(lang[:2], _WDDW2_OP_MODE_DISPLAY["en"])
+    return table.get(mode, mode)
+
 
 def _parse_temp_unit(unit_str: str | None) -> str:
     """Map API unitOfMeasure string to HA temperature unit."""
@@ -47,7 +60,12 @@ async def async_setup_entry(
                     entities.append(
                         BoschComWddw2WaterHeater(coordinator=coordinator, field=dhw_id)
                     )
-        elif coordinator.data.device.get("deviceType") in ("k40", "k30"):
+        elif coordinator.data.device.get("deviceType") in (
+            "k40",
+            "k30",
+            "icom",
+            "rrc2",
+        ):
             _migrate_unique_id(entity_registry, coordinator.unique_id, "waterheater")
             entities.append(
                 BoschComK40WaterHeater(coordinator=coordinator, field="waterheater")
@@ -103,9 +121,7 @@ class BoschComK40WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         """Initialize water heater entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "dhw"
-        # The K40 API exposes a single DHW circuit without a numeric id, so the
-        # "circuit" placeholder is set to a fixed "dhw1" label for the name.
-        self._attr_translation_placeholders = {"circuit": "dhw1"}
+        self._attr_translation_placeholders = {"circuit": "1"}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._attr_suggested_object_id = field + "_waterheater"
@@ -160,10 +176,7 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
 
     _attr_has_entity_name = True
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
-    _attr_supported_features = (
-        WaterHeaterEntityFeature.OPERATION_MODE
-        | WaterHeaterEntityFeature.TARGET_TEMPERATURE
-    )
+    _attr_supported_features = WaterHeaterEntityFeature(0)
     _attr_target_temperature_step = 1
 
     def __init__(
@@ -174,7 +187,7 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         """Initialize water heater entity."""
         super().__init__(coordinator)
         self._attr_translation_key = "dhw"
-        self._attr_translation_placeholders = {"circuit": field}
+        self._attr_translation_placeholders = {"circuit": re.sub(r"\D", "", field)}
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{field}"
         self._attr_suggested_object_id = field + "_waterheater"
@@ -184,12 +197,16 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
 
         self._attr_min_temp = 36
         self._attr_max_temp = 60
-        self._attr_target_temperature = 45  # será atualizado em set_attr()
+        self._attr_target_temperature = None
         self._attr_current_temperature = None
 
-        # Call this in __init__ so data is populated right away, since it's
-        # already available in the coordinator data.
         self.set_attr()
+
+    async def async_added_to_hass(self) -> None:
+        """Re-apply set_attr once self.hass is available (correct language)."""
+        await super().async_added_to_hass()
+        self.set_attr()
+        self.async_write_ha_state()
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -198,18 +215,31 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
         self.async_write_ha_state()
 
     async def async_set_operation_mode(self, operation_mode: str) -> None:
-        """Set new target operation mode."""
+        """Set new target operation mode.
+
+        Receives the display label (translated); maps back to the raw API value.
+        """
+        lang = self.hass.config.language
+        reverse = {
+            _translate_op_mode(lang, k): k
+            for k in _WDDW2_OP_MODE_DISPLAY.get(lang[:2], _WDDW2_OP_MODE_DISPLAY["en"])
+        }
+        api_mode = reverse.get(operation_mode, operation_mode)
+
         for ref in self.coordinator.data.dhw_circuits:
             dhw_id = ref["id"].split("/")[-1]
-            if dhw_id == self.field:
-                await self.coordinator.bhc.async_put_dhw_operation_mode(
-                    self.coordinator.unique_id, dhw_id, operation_mode
-                )
+            if dhw_id != self.field:
+                continue
+            op_mode_node = ref.get("operationMode") or {}
+            if op_mode_node.get("writeable", 1) == 0:
+                return
+            await self.coordinator.bhc.async_put_dhw_operation_mode(
+                self.coordinator.unique_id, dhw_id, api_mode
+            )
         await self.coordinator.async_request_refresh()
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
-        """Set new target temperature."""
-
+        """Set new target temperature (only when device supports free setpoint)."""
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
             return
 
@@ -224,6 +254,10 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
             dhw_id = ref["id"].split("/")[-1]
             if dhw_id != self.field:
                 continue
+            temp_level = ref.get("tempLevel") or {}
+            manual = temp_level.get("manual") or {}
+            if manual.get("writeable", 1) == 0:
+                return
             if current_mode != "manual":
                 await self.coordinator.bhc.async_put_dhw_operation_mode(
                     self.coordinator.unique_id, dhw_id, "manual"
@@ -232,7 +266,6 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
                 self.coordinator.unique_id, dhw_id, "manual", t
             )
 
-        # pede refresh para refletir no UI
         await self.coordinator.async_request_refresh()
 
     def _set_domestic_hot_water_circuits(
@@ -244,29 +277,54 @@ class BoschComWddw2WaterHeater(CoordinatorEntity, WaterHeaterEntity):
             if dhw_id != self.field:
                 continue
 
-            op = (ref.get("operationMode") or {}).get("value")
-            allowed = (ref.get("operationMode") or {}).get("allowedValues") or []
-            self._attr_operation_list = allowed
-            self._attr_current_operation = op or self._attr_current_operation
+            op_mode_node = ref.get("operationMode") or {}
+            op = op_mode_node.get("value")
+            lang = self.hass.config.language if self.hass else "en"
 
-            # limites do setpoint manual (usados no clamp e stepper)
-            manual = (ref.get("tempLevel") or {}).get("manual") or {}
-            self._attr_min_temp = manual.get("minValue", self._attr_min_temp)
-            self._attr_max_temp = manual.get("maxValue", self._attr_max_temp)
+            op_writable = op_mode_node.get("writeable", 1)
+            temp_level = ref.get("tempLevel") or {}
 
-            unit_str = manual.get("unitOfMeasure")
-            if unit_str:
-                self._attr_temperature_unit = _parse_temp_unit(unit_str)
+            features = WaterHeaterEntityFeature(0)
+            allowed = op_mode_node.get("allowedValues") or []
+            self._attr_operation_list = [_translate_op_mode(lang, m) for m in allowed]
+            if op_writable != 0:
+                features |= WaterHeaterEntityFeature.OPERATION_MODE
 
-            # o setpoint alvo depende do modo atual: tempLevel[mode].value
-            tl = ref.get("tempLevel") or {}
-            set_for_mode = (tl.get(op) or {}).get("value")
-            if isinstance(set_for_mode, (int, float)):
-                self._attr_target_temperature = set_for_mode
+            self._attr_current_operation = (
+                _translate_op_mode(lang, op) if op else self._attr_current_operation
+            )
 
-            # se tiveres uma “current water temperature” real, podes meter aqui;
-            # caso não exista, deixa None para não confundir
-            self._attr_current_temperature = None
+            coord_temps = getattr(self._coordinator, "wddw2_temp_levels", {})
+            lib_temps = {
+                k: v.get("value")
+                for k, v in temp_level.items()
+                if isinstance(v, dict) and "value" in v
+            }
+            effective_temps = {**coord_temps, **lib_temps}
+
+            if effective_temps:
+                target = effective_temps.get(op)
+                if isinstance(target, (int, float)):
+                    self._attr_target_temperature = target
+                if lib_temps:
+                    features |= WaterHeaterEntityFeature.TARGET_TEMPERATURE
+            self._attr_supported_features = features
+
+            outlet = ref.get("outletTemperature") or {}
+            if isinstance(outlet, dict) and "value" in outlet:
+                self._attr_current_temperature = outlet["value"]
+                unit_str = outlet.get("unitOfMeasure")
+                if unit_str:
+                    self._attr_temperature_unit = _parse_temp_unit(unit_str)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Expose mode-specific setpoint temperature as attribute when not adjustable."""
+        if WaterHeaterEntityFeature.TARGET_TEMPERATURE in self._attr_supported_features:
+            return {}
+        if self._attr_target_temperature is not None:
+            return {"solltemperatur": self._attr_target_temperature}
+        return {}
 
     def set_attr(self) -> None:
         """Populate attributes with data from the coordinator."""

--- a/tests/test_wddw2.py
+++ b/tests/test_wddw2.py
@@ -87,6 +87,7 @@ def _mock_wddw2_coordinator(
     coord.async_request_refresh = AsyncMock()
     coord.bhc = Mock()
     coord.bhc._async_http_request = AsyncMock()
+    coord.bhc.get_token = AsyncMock()
     return coord
 
 

--- a/tests/test_wddw2.py
+++ b/tests/test_wddw2.py
@@ -1,0 +1,506 @@
+"""Tests for wddw2 coordinator, water heater and switch entities."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+from homeassistant.components.water_heater import WaterHeaterEntityFeature
+from homeassistant.const import CONF_CODE, CONF_TOKEN, CONF_USERNAME
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from homecom_alt import BHCDeviceWddw2
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bosch_homecom.const import CONF_DEVICES, CONF_REFRESH, DOMAIN
+from custom_components.bosch_homecom.coordinator import BoschComModuleCoordinatorWddw2
+from custom_components.bosch_homecom.switch import (
+    BoschComWddw2HolidayModeSwitch,
+    BoschComWddw2SafetyTempSwitch,
+)
+from custom_components.bosch_homecom.water_heater import (
+    BoschComWddw2WaterHeater,
+    _parse_temp_unit,
+    _translate_op_mode,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bhc():
+    return Mock()
+
+
+@pytest.fixture
+def device():
+    return {"deviceId": "102051881", "deviceType": "wddw2"}
+
+
+@pytest.fixture
+def firmware():
+    return {"value": "2.0.0"}
+
+
+@pytest.fixture
+def entry():
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="test-user",
+        unique_id="test-user",
+        data={
+            CONF_DEVICES: {"102051881_wddw2": True},
+            CONF_REFRESH: "mock_refresh",
+            CONF_TOKEN: "mock_token",
+            CONF_USERNAME: "test-user",
+            CONF_CODE: "valid_code",
+        },
+    )
+
+
+def _make_wddw2_data(dhw_circuits=None):
+    return BHCDeviceWddw2(
+        device={"deviceId": "102051881", "deviceType": "wddw2"},
+        firmware={"value": "2.0.0"},
+        notifications=[],
+        dhw_circuits=dhw_circuits or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a mock coordinator with pre-populated wddw2 state
+# ---------------------------------------------------------------------------
+
+
+def _mock_wddw2_coordinator(
+    safety_temperature="off",
+    holiday_mode="off",
+    temp_levels=None,
+    dhw_circuits=None,
+):
+    coord = Mock()
+    coord.unique_id = "102051881"
+    coord.device_info = Mock()
+    coord.wddw2_safety_temperature = safety_temperature
+    coord.wddw2_holiday_mode = holiday_mode
+    coord.wddw2_temp_levels = temp_levels if temp_levels is not None else {}
+    coord.data = _make_wddw2_data(dhw_circuits=dhw_circuits or [])
+    coord.async_request_refresh = AsyncMock()
+    coord.bhc = Mock()
+    coord.bhc._async_http_request = AsyncMock()
+    return coord
+
+
+# ---------------------------------------------------------------------------
+# Coordinator tests
+# ---------------------------------------------------------------------------
+
+
+def test_wddw2_coordinator_init(hass, entry, bhc, device, firmware):
+    """Extra wddw2 attributes are initialised to safe defaults."""
+    entry.add_to_hass(hass)
+    coordinator = BoschComModuleCoordinatorWddw2(
+        hass, bhc, device, firmware, entry, False
+    )
+    assert coordinator.wddw2_safety_temperature is None
+    assert coordinator.wddw2_holiday_mode is None
+    assert coordinator.wddw2_temp_levels == {}
+
+
+@pytest.mark.asyncio
+async def test_wddw2_coordinator_update_populates_extra_attributes(
+    hass, entry, bhc, device, firmware
+):
+    """Successful update fetches all four extra endpoints and stores results."""
+    entry.add_to_hass(hass)
+    coordinator = BoschComModuleCoordinatorWddw2(
+        hass, bhc, device, firmware, entry, False
+    )
+
+    base_data = _make_wddw2_data()
+    bhc.async_update = AsyncMock(return_value=base_data)
+    bhc.async_action_universal_get = AsyncMock(
+        side_effect=[
+            {"value": "on"},  # safetyTemperature
+            {"value": "off"},  # holidayMode
+            {"value": 57.0},  # manualsetpoint
+            {"value": 42.0},  # temperatureLevels/bath
+        ]
+    )
+
+    await coordinator._async_update_data()
+
+    assert coordinator.wddw2_safety_temperature == "on"
+    assert coordinator.wddw2_holiday_mode == "off"
+    assert coordinator.wddw2_temp_levels == {"manual": 57.0, "bath": 42.0}
+
+
+@pytest.mark.asyncio
+async def test_wddw2_coordinator_safety_temp_endpoint_failure_is_silent(
+    hass, entry, bhc, device, firmware
+):
+    """Failure on safetyTemperature endpoint does not raise; attribute stays None."""
+    entry.add_to_hass(hass)
+    coordinator = BoschComModuleCoordinatorWddw2(
+        hass, bhc, device, firmware, entry, False
+    )
+
+    bhc.async_update = AsyncMock(return_value=_make_wddw2_data())
+    bhc.async_action_universal_get = AsyncMock(side_effect=Exception("timeout"))
+
+    await coordinator._async_update_data()
+
+    assert coordinator.wddw2_safety_temperature is None
+    assert coordinator.wddw2_holiday_mode is None
+    assert coordinator.wddw2_temp_levels == {}
+
+
+@pytest.mark.asyncio
+async def test_wddw2_coordinator_temp_levels_ignores_non_numeric(
+    hass, entry, bhc, device, firmware
+):
+    """Non-numeric temperature values from the API are not stored."""
+    entry.add_to_hass(hass)
+    coordinator = BoschComModuleCoordinatorWddw2(
+        hass, bhc, device, firmware, entry, False
+    )
+
+    bhc.async_update = AsyncMock(return_value=_make_wddw2_data())
+    bhc.async_action_universal_get = AsyncMock(
+        side_effect=[
+            None,  # safetyTemperature returns None
+            {"value": "off"},  # holidayMode
+            {"value": "N/A"},  # manualsetpoint — non-numeric
+            {"value": 42.0},  # bath — numeric
+        ]
+    )
+
+    await coordinator._async_update_data()
+
+    assert coordinator.wddw2_temp_levels == {"bath": 42.0}
+
+
+@pytest.mark.asyncio
+async def test_wddw2_coordinator_update_base_error_raises_update_failed(
+    hass, entry, bhc, device, firmware
+):
+    """Base update errors propagate as UpdateFailed (extra endpoints not called)."""
+    from homecom_alt import ApiError
+
+    entry.add_to_hass(hass)
+    coordinator = BoschComModuleCoordinatorWddw2(
+        hass, bhc, device, firmware, entry, False
+    )
+    bhc.async_update = AsyncMock(side_effect=ApiError("error"))
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+
+# ---------------------------------------------------------------------------
+# _translate_op_mode and _parse_temp_unit helper tests
+# ---------------------------------------------------------------------------
+
+
+def test_translate_op_mode_german():
+    assert _translate_op_mode("de", "manual") == "Manuell"
+    assert _translate_op_mode("de", "bath") == "Sicherheitstemperatur"
+
+
+def test_translate_op_mode_english():
+    assert _translate_op_mode("en", "manual") == "Manual"
+    assert _translate_op_mode("en", "bath") == "Safety Temperature"
+
+
+def test_translate_op_mode_unknown_language_falls_back_to_english():
+    assert _translate_op_mode("fr", "manual") == "Manual"
+
+
+def test_translate_op_mode_unknown_mode_returns_raw_value():
+    assert _translate_op_mode("en", "eco") == "eco"
+
+
+def test_parse_temp_unit_fahrenheit():
+    from homeassistant.const import UnitOfTemperature
+
+    assert _parse_temp_unit("F") == UnitOfTemperature.FAHRENHEIT
+
+
+def test_parse_temp_unit_celsius_for_anything_else():
+    from homeassistant.const import UnitOfTemperature
+
+    assert _parse_temp_unit("C") == UnitOfTemperature.CELSIUS
+    assert _parse_temp_unit(None) == UnitOfTemperature.CELSIUS
+    assert _parse_temp_unit("K") == UnitOfTemperature.CELSIUS
+
+
+# ---------------------------------------------------------------------------
+# BoschComWddw2WaterHeater tests
+# ---------------------------------------------------------------------------
+
+_DHW_READ_ONLY = [
+    {
+        "id": "/dhwCircuits/dhw1",
+        "operationMode": {
+            "value": "manual",
+            "writeable": 0,
+            "allowedValues": ["manual", "bath"],
+        },
+        "outletTemperature": {"value": 45.0, "unitOfMeasure": "C"},
+        "tempLevel": {},
+    }
+]
+
+_DHW_WRITABLE = [
+    {
+        "id": "/dhwCircuits/dhw1",
+        "operationMode": {
+            "value": "manual",
+            "writeable": 1,
+            "allowedValues": ["manual", "bath"],
+        },
+        "outletTemperature": {"value": 50.0, "unitOfMeasure": "C"},
+        "tempLevel": {
+            "manual": {"value": 57.0, "writeable": 1},
+            "bath": {"value": 42.0, "writeable": 1},
+        },
+    }
+]
+
+
+def test_wddw2_water_heater_extra_state_attributes_when_readonly():
+    """solltemperatur is exposed as attribute when TARGET_TEMPERATURE is not supported."""
+    coord = _mock_wddw2_coordinator(
+        temp_levels={"manual": 57.0, "bath": 42.0},
+        dhw_circuits=_DHW_READ_ONLY,
+    )
+    entity = BoschComWddw2WaterHeater(coordinator=coord, field="dhw1")
+
+    attrs = entity.extra_state_attributes
+    assert "solltemperatur" in attrs
+    assert attrs["solltemperatur"] == 57.0
+
+
+def test_wddw2_water_heater_extra_state_attributes_empty_when_writable():
+    """extra_state_attributes is empty when TARGET_TEMPERATURE feature is active."""
+    coord = _mock_wddw2_coordinator(dhw_circuits=_DHW_WRITABLE)
+    entity = BoschComWddw2WaterHeater(coordinator=coord, field="dhw1")
+
+    assert entity.extra_state_attributes == {}
+
+
+def test_wddw2_water_heater_target_temperature_disabled_for_readonly_device():
+    """TARGET_TEMPERATURE is not in supported_features for read-only devices."""
+    coord = _mock_wddw2_coordinator(
+        temp_levels={"manual": 57.0},
+        dhw_circuits=_DHW_READ_ONLY,
+    )
+    entity = BoschComWddw2WaterHeater(coordinator=coord, field="dhw1")
+
+    assert WaterHeaterEntityFeature.TARGET_TEMPERATURE not in entity.supported_features
+
+
+def test_wddw2_water_heater_target_temperature_enabled_for_writable_device():
+    """TARGET_TEMPERATURE is in supported_features when library provides tempLevel."""
+    coord = _mock_wddw2_coordinator(dhw_circuits=_DHW_WRITABLE)
+    entity = BoschComWddw2WaterHeater(coordinator=coord, field="dhw1")
+
+    assert WaterHeaterEntityFeature.TARGET_TEMPERATURE in entity.supported_features
+
+
+def test_wddw2_water_heater_uses_coord_temps_as_fallback():
+    """When tempLevel is empty, coordinator.wddw2_temp_levels provides temperature."""
+    coord = _mock_wddw2_coordinator(
+        temp_levels={"manual": 57.0},
+        dhw_circuits=_DHW_READ_ONLY,
+    )
+    entity = BoschComWddw2WaterHeater(coordinator=coord, field="dhw1")
+
+    assert entity._attr_target_temperature == 57.0
+
+
+def test_wddw2_water_heater_lib_temps_override_coord_temps():
+    """Library-provided tempLevel values override coordinator fallback values."""
+    coord = _mock_wddw2_coordinator(
+        temp_levels={"manual": 99.0},  # stale fallback
+        dhw_circuits=_DHW_WRITABLE,  # lib provides 57.0
+    )
+    entity = BoschComWddw2WaterHeater(coordinator=coord, field="dhw1")
+
+    assert entity._attr_target_temperature == 57.0
+
+
+def test_wddw2_water_heater_current_temperature_from_outlet():
+    """current_temperature is read from outletTemperature."""
+    coord = _mock_wddw2_coordinator(dhw_circuits=_DHW_READ_ONLY)
+    entity = BoschComWddw2WaterHeater(coordinator=coord, field="dhw1")
+
+    assert entity._attr_current_temperature == 45.0
+
+
+def test_wddw2_water_heater_ignores_wrong_dhw_id():
+    """Entity only processes the dhw circuit matching its field."""
+    coord = _mock_wddw2_coordinator(
+        temp_levels={"manual": 57.0},
+        dhw_circuits=_DHW_READ_ONLY,
+    )
+    entity = BoschComWddw2WaterHeater(coordinator=coord, field="dhw2")
+
+    # dhw1 data must not be applied to a dhw2 entity
+    assert entity._attr_target_temperature is None
+
+
+@pytest.mark.asyncio
+async def test_wddw2_water_heater_set_temperature_early_return_for_readonly(hass):
+    """async_set_temperature returns early when tempLevel.manual.writeable is 0."""
+    # This tests the explicit writeable=0 guard in async_set_temperature.
+    # For TR4001 the guard is never reached because tempLevel is empty — HA
+    # simply doesn't show the temperature slider (TARGET_TEMPERATURE not enabled).
+    dhw_readonly_manual = [
+        {
+            "id": "/dhwCircuits/dhw1",
+            "operationMode": {
+                "value": "manual",
+                "writeable": 1,
+                "allowedValues": ["manual", "bath"],
+            },
+            "outletTemperature": {"value": 45.0, "unitOfMeasure": "C"},
+            "tempLevel": {
+                "manual": {"value": 57.0, "writeable": 0},
+            },
+        }
+    ]
+    coord = _mock_wddw2_coordinator(dhw_circuits=dhw_readonly_manual)
+    coord.bhc.async_put_dhw_operation_mode = AsyncMock()
+    coord.bhc.async_set_dhw_temp_level = AsyncMock()
+    entity = BoschComWddw2WaterHeater(coordinator=coord, field="dhw1")
+    entity.hass = hass
+
+    await entity.async_set_temperature(temperature=55.0)
+
+    coord.bhc.async_set_dhw_temp_level.assert_not_called()
+    coord.async_request_refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_wddw2_water_heater_set_operation_mode_readonly_returns_early(hass):
+    """async_set_operation_mode returns early when operationMode is writeable=0."""
+    coord = _mock_wddw2_coordinator(dhw_circuits=_DHW_READ_ONLY)
+    entity = BoschComWddw2WaterHeater(coordinator=coord, field="dhw1")
+    entity.hass = hass
+    hass.config.language = "en"
+
+    await entity.async_set_operation_mode("Manual")
+
+    coord.bhc.async_put_dhw_operation_mode.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_wddw2_water_heater_set_operation_mode_writable_calls_api(hass):
+    """async_set_operation_mode sends the API call when writeable != 0."""
+    coord = _mock_wddw2_coordinator(dhw_circuits=_DHW_WRITABLE)
+    coord.bhc.async_put_dhw_operation_mode = AsyncMock()
+    entity = BoschComWddw2WaterHeater(coordinator=coord, field="dhw1")
+    entity.hass = hass
+    hass.config.language = "en"
+
+    await entity.async_set_operation_mode("Safety Temperature")
+
+    coord.bhc.async_put_dhw_operation_mode.assert_called_once()
+    coord.async_request_refresh.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# BoschComWddw2SafetyTempSwitch / BoschComWddw2HolidayModeSwitch tests
+# ---------------------------------------------------------------------------
+
+
+def test_safety_temp_switch_is_on_when_value_on():
+    coord = _mock_wddw2_coordinator(safety_temperature="on")
+    switch = BoschComWddw2SafetyTempSwitch(coordinator=coord)
+    assert switch.is_on is True
+
+
+def test_safety_temp_switch_is_off_when_value_off():
+    coord = _mock_wddw2_coordinator(safety_temperature="off")
+    switch = BoschComWddw2SafetyTempSwitch(coordinator=coord)
+    assert switch.is_on is False
+
+
+def test_safety_temp_switch_is_none_when_no_coordinator_value():
+    coord = _mock_wddw2_coordinator(safety_temperature=None)
+    switch = BoschComWddw2SafetyTempSwitch(coordinator=coord)
+    assert switch.is_on is None
+
+
+def test_holiday_mode_switch_is_on():
+    coord = _mock_wddw2_coordinator(holiday_mode="on")
+    switch = BoschComWddw2HolidayModeSwitch(coordinator=coord)
+    assert switch.is_on is True
+
+
+def test_holiday_mode_switch_is_off():
+    coord = _mock_wddw2_coordinator(holiday_mode="off")
+    switch = BoschComWddw2HolidayModeSwitch(coordinator=coord)
+    assert switch.is_on is False
+
+
+@pytest.mark.asyncio
+async def test_safety_temp_switch_turn_on_calls_put_and_refresh():
+    coord = _mock_wddw2_coordinator(safety_temperature="off")
+    switch = BoschComWddw2SafetyTempSwitch(coordinator=coord)
+
+    await switch.async_turn_on()
+
+    coord.bhc._async_http_request.assert_called_once()
+    call_args = coord.bhc._async_http_request.call_args
+    assert call_args[0][0] == "put"
+    assert call_args[0][2] == {"value": "on"}
+    coord.async_request_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_safety_temp_switch_turn_off_calls_put_and_refresh():
+    coord = _mock_wddw2_coordinator(safety_temperature="on")
+    switch = BoschComWddw2SafetyTempSwitch(coordinator=coord)
+
+    await switch.async_turn_off()
+
+    coord.bhc._async_http_request.assert_called_once()
+    call_args = coord.bhc._async_http_request.call_args
+    assert call_args[0][2] == {"value": "off"}
+    coord.async_request_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_holiday_mode_switch_turn_on_calls_correct_resource_path():
+    coord = _mock_wddw2_coordinator(holiday_mode="off")
+    switch = BoschComWddw2HolidayModeSwitch(coordinator=coord)
+
+    await switch.async_turn_on()
+
+    call_args = coord.bhc._async_http_request.call_args
+    url: str = call_args[0][1]
+    assert "/resource/system/holidayMode" in url
+    assert call_args[0][2] == {"value": "on"}
+
+
+def test_safety_temp_switch_handle_coordinator_update_sets_is_on():
+    coord = _mock_wddw2_coordinator(safety_temperature="on")
+    switch = BoschComWddw2SafetyTempSwitch(coordinator=coord)
+    switch.async_write_ha_state = Mock()
+
+    coord.wddw2_safety_temperature = "off"
+    switch._handle_coordinator_update()
+
+    assert switch._attr_is_on is False
+    switch.async_write_ha_state.assert_called_once()
+
+
+def test_safety_temp_switch_handle_coordinator_update_none_stays_none():
+    coord = _mock_wddw2_coordinator(safety_temperature=None)
+    switch = BoschComWddw2SafetyTempSwitch(coordinator=coord)
+    switch.async_write_ha_state = Mock()
+
+    switch._handle_coordinator_update()
+
+    assert switch._attr_is_on is None


### PR DESCRIPTION
## Summary

Adds complete Home Assistant support for the **Bosch Tronic TR4001** (`wddw2` device type). The TR4001 is a read-only instantaneous water heater where `operationMode.writeable=0` and `tempLevel` is empty in the library response — the standard coordinator/entity pattern needed several workarounds.

- **Coordinator**: `BoschComModuleCoordinatorWddw2` extended with `__init__` and `_async_update_data` override that fetches four additional endpoints after the normal update: `safetyTemperature`, `holidayMode`, and per-mode temperatures (`manualsetpoint`, `temperatureLevels/bath`). All extra fetches are silent-fail (optional data, non-blocking).
- **Water heater**: `BoschComWddw2WaterHeater` improved with capability detection (`TARGET_TEMPERATURE` only enabled when library provides `tempLevel`), German/English operation mode translation via `_translate_op_mode`, temperature fallback from coordinator (`wddw2_temp_levels`), and `extra_state_attributes.solltemperatur` for automation/KNX access. `async_added_to_hass` override re-applies attributes with correct HA language after startup.
- **Switches**: Two new entities — `BoschComWddw2SafetyTempSwitch` and `BoschComWddw2HolidayModeSwitch` — backed by direct PUT on `/resource/dhwCircuits/dhw1/safetyTemperature` and `/resource/system/holidayMode` respectively. Only created when the coordinator confirms the endpoint is reachable.
- **Notification sensor**: `BoschComSensorNotificationsWddw2` improved to filter historical entries (`act=="H"`), resolve error codes via `WDDW2_NOTIFICATION_CODES`, and expose full notification history in `extra_state_attributes.verlauf`.
- **Tests**: 32 new tests in `tests/test_wddw2.py` covering coordinator extra-endpoint logic, water heater capability detection, switch on/off and PUT behaviour.

## Notes

- The switch PUT uses `bhc._async_http_request` directly (no public universal-PUT in homecom_alt). Happy to open a companion PR to homecom_alt adding a public method if preferred.
- `act=="H"` is interpreted as "historical/expired" based on observed behaviour with error codes E01/E07 in the HomeCom Easy app. The full `act`-value semantics are unknown to me — see homecom_alt issue #73.

## Test plan

- [ ] `tox -e lint` passes (flake8, isort, black)
- [ ] `tox -e type` passes (mypy)
- [ ] `tox -e py312` passes (32 new wddw2 tests + existing suite)
- [ ] Manually tested on real Bosch Tronic TR4001 hardware:
  - Water heater entity shows correct mode and temperature
  - Safety Temperature switch toggles in HA and Bosch app
  - Holiday Mode switch toggles in HA and Bosch app
  - Notification sensor shows active errors, filters historical ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)