### PR TITLE
feat: expose additional K40 endpoints as HA entities

### DIFF
--- a/DEPENDENCY_NOTES.md
+++ b/DEPENDENCY_NOTES.md
@@ -1,0 +1,31 @@
+# Dependency Notes
+
+## homecom_alt library (required for this branch)
+
+The `feature/explore-k40-endpoints` branch adds entities that currently use
+`coordinator.async_put_extra_endpoint()` for the 2 endpoints not yet in
+`homecom_alt`:
+
+- `/heatSources/additionalHeater/operationMode`
+- `/system/silentMode/enabled`
+
+A corresponding PR has been prepared for `homecom_alt`:
+- Branch: `feature/additional-heater-silent-mode` on `homecom_alt`
+- Adds: `BOSCHCOM_ENDPOINT_HS_ADDITIONAL_HEATER`, `BOSCHCOM_ENDPOINT_SILENT_MODE`
+- Adds: `async_get/put_additional_heater_mode()`, `async_get/put_silent_mode()`
+
+### Merge order
+
+1. **First**: Merge & release `homecom_alt` with the new endpoints
+2. **Then**: Update this integration to use the library methods directly
+   (replace `async_put_extra_endpoint` with `bhc.async_put_additional_heater_mode`)
+3. Bump `homecom_alt` version requirement in this repo
+
+### Local development (testing before library release)
+
+```bash
+pip install -e /path/to/homecom_alt
+```
+
+This installs the local library with the new endpoints, allowing the
+integration to be tested end-to-end before the PyPI release.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Home Assistant custom integration for Bosch HomeCom Easy-connected appliances.
 | Device Type | Examples |
 |-------------|----------|
 | **RAC** | Climate Class 3000i\*, 5000i, 6000i |
-| **K30 / K40** | Bosch boilers, Buderus Logatherm WLW 186i (MX300) |
+| **K30 / K40** | Bosch boilers, Bosch Compress 5800i/6800i heat pumps, Buderus Logatherm WLW 186i (MX300) |
 | **ICOM** | IVT Aero Series, Bosch Compress 7000i/7001i AW heat pumps |
 | **RRC2** | Bosch thermostats (CT200) |
 | **WDDW2** | Hydronext 5700s water heaters |

--- a/custom_components/bosch_homecom/button.py
+++ b/custom_components/bosch_homecom/button.py
@@ -8,7 +8,10 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_WB_LABEL, DEFAULT_WB_LABEL
-from .coordinator import BoschComModuleCoordinatorCommodule
+from .coordinator import (
+    BoschComModuleCoordinatorCommodule,
+    BoschComModuleCoordinatorK40,
+)
 
 PARALLEL_UPDATES = 1
 
@@ -40,6 +43,13 @@ async def async_setup_entry(
                         coordinator=coordinator, cp_id=cp_id
                     )
                 )
+    # Extra K40 button entities
+    for coordinator in coordinators:
+        if isinstance(coordinator, BoschComModuleCoordinatorK40):
+            # DHW charge button — available if device has dhw_circuits
+            if coordinator.data.dhw_circuits:
+                entities.append(BoschComK40DhwChargeButton(coordinator))
+
     async_add_entities(entities)
 
 
@@ -126,3 +136,30 @@ class BoschComCommodulePauseChargingButton(CoordinatorEntity, ButtonEntity):
             device_id, self._cp_id, label
         )
         await self._coordinator.async_request_refresh()
+
+
+# ===================================================================
+# Extra K40 button (endpoints not yet in homecom_alt library)
+# ===================================================================
+
+
+class BoschComK40DhwChargeButton(CoordinatorEntity, ButtonEntity):
+    """Button to trigger a one-time DHW charge (extra hot water)."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(self, coordinator: BoschComModuleCoordinatorK40) -> None:
+        """Initialize DHW charge button."""
+        super().__init__(coordinator)
+        self._attr_translation_key = "dhw_extra_charge"
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = f"{coordinator.unique_id}-dhw_extra_charge"
+        self._attr_suggested_object_id = "dhw_extra_charge"
+
+    async def async_press(self) -> None:
+        """Trigger a single hot water charge."""
+        await self.coordinator.bhc.async_set_dhw_charge(
+            self.coordinator.data.device["deviceId"], "dhw1", "start"
+        )
+        await self.coordinator.async_request_refresh()

--- a/custom_components/bosch_homecom/coordinator.py
+++ b/custom_components/bosch_homecom/coordinator.py
@@ -146,6 +146,50 @@ class BoschComModuleCoordinatorRac(BoschComModuleCoordinatorBase[BHCDeviceRac]):
 class BoschComModuleCoordinatorK40(BoschComModuleCoordinatorBase[BHCDeviceK40]):
     """A coordinator to manage the fetching of BoschCom data."""
 
+    # Endpoints not yet covered by the homecom_alt library bulk fetch.
+    # Once these are upstreamed to homecom_alt, they can be removed here.
+    EXTRA_ENDPOINTS = {
+        "additional_heater": "/resource/heatSources/additionalHeater/operationMode",
+        "silent_mode": "/resource/system/silentMode/enabled",
+        "dhw_charge_duration": "/resource/dhwCircuits/dhw1/chargeDuration",
+    }
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize K40 coordinator with extra endpoint state."""
+        super().__init__(*args, **kwargs)
+        self.extra_data: dict[str, dict | None] = {}
+
+    async def _async_update_data(self) -> BHCDeviceK40:
+        """Update data via library, then fetch extra endpoints."""
+        data = await super()._async_update_data()
+        await self._fetch_extra_endpoints()
+        return data
+
+    async def _fetch_extra_endpoints(self) -> None:
+        """Fetch extra endpoints not in homecom_alt, failing gracefully."""
+        for key, path in self.EXTRA_ENDPOINTS.items():
+            try:
+                result = await self.bhc.async_action_universal_get(self.unique_id, path)
+                self.extra_data[key] = result if result else None
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug(
+                    "Device %s: endpoint %s not available", self.unique_id, key
+                )
+                self.extra_data[key] = None
+
+    async def async_put_extra_endpoint(self, key: str, value) -> None:
+        """PUT a value to an extra endpoint by key."""
+        from homecom_alt.const import BOSCHCOM_DOMAIN, BOSCHCOM_ENDPOINT_GATEWAYS
+
+        path = self.EXTRA_ENDPOINTS[key]
+        await self.bhc.get_token()
+        await self.bhc._async_http_request(
+            "put",
+            BOSCHCOM_DOMAIN + BOSCHCOM_ENDPOINT_GATEWAYS + self.unique_id + path,
+            {"value": value},
+            1,
+        )
+
     def _build_device_data(self, data: BHCDeviceK40) -> BHCDeviceK40:
         """Build K40 device data."""
         return BHCDeviceK40(

--- a/custom_components/bosch_homecom/number.py
+++ b/custom_components/bosch_homecom/number.py
@@ -57,6 +57,14 @@ async def async_setup_entry(
             entities.extend(_build_rrc2_numbers(coordinator))
         if coordinator.data.device["deviceType"] == "icom":
             entities.extend(_build_icom_dhw_numbers(coordinator))
+    # Extra K40 number entities
+    for coordinator in coordinators:
+        if isinstance(coordinator, BoschComModuleCoordinatorK40):
+            # DHW charge duration — available if extra_data has it
+            dhw_dur = coordinator.extra_data.get("dhw_charge_duration")
+            if isinstance(dhw_dur, dict) and dhw_dur.get("writeable"):
+                entities.append(BoschComK40DhwChargeDurationNumber(coordinator))
+
     async_add_entities(entities)
 
 
@@ -610,3 +618,50 @@ def _build_icom_dhw_numbers(
             )
 
     return entities
+
+
+# ===================================================================
+# Extra K40 number (endpoints not yet in homecom_alt library)
+# ===================================================================
+
+
+class BoschComK40DhwChargeDurationNumber(CoordinatorEntity, NumberEntity):
+    """Number entity for DHW charge duration in minutes."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(self, coordinator: BoschComModuleCoordinatorK40) -> None:
+        """Initialize DHW charge duration number."""
+        super().__init__(coordinator)
+        self._attr_translation_key = "dhw_charge_duration"
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = f"{coordinator.unique_id}-dhw_charge_duration"
+        self._attr_suggested_object_id = "dhw_charge_duration"
+        self._attr_native_unit_of_measurement = "min"
+        self._attr_native_min_value = 60
+        self._attr_native_max_value = 2880
+        self._attr_native_step = 30
+
+    @property
+    def native_value(self) -> float | None:
+        """Return current duration value."""
+        data = self.coordinator.extra_data.get("dhw_charge_duration")
+        if data and isinstance(data, dict):
+            return data.get("value")
+        return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the charge duration."""
+        await self.coordinator.bhc.async_set_dhw_charge_duration(
+            self.coordinator.data.device["deviceId"], "dhw1", str(int(value))
+        )
+        await self.coordinator.async_request_refresh()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data."""
+        data = self.coordinator.extra_data.get("dhw_charge_duration")
+        if data and isinstance(data, dict):
+            self._attr_native_value = data.get("value")
+        self.async_write_ha_state()

--- a/custom_components/bosch_homecom/select.py
+++ b/custom_components/bosch_homecom/select.py
@@ -192,6 +192,33 @@ async def async_setup_entry(
                             allowed_values=allowed_values,
                         )
                     )
+    # Extra K40 select entities from extra_data
+    for coordinator in coordinators:
+        if isinstance(coordinator, BoschComModuleCoordinatorK40):
+            extra = coordinator.extra_data
+            ah = extra.get("additional_heater")
+            if isinstance(ah, dict) and "allowedValues" in ah:
+                entities.append(
+                    BoschComK40ExtraSelect(
+                        coordinator,
+                        "additional_heater",
+                        "additional_heater_mode",
+                        "additional_heater",
+                        ah["allowedValues"],
+                    )
+                )
+            sm = extra.get("silent_mode")
+            if isinstance(sm, dict) and "allowedValues" in sm:
+                entities.append(
+                    BoschComK40ExtraSelect(
+                        coordinator,
+                        "silent_mode",
+                        "silent_mode",
+                        "silent_mode",
+                        sm["allowedValues"],
+                    )
+                )
+
     async_add_entities(entities)
 
 
@@ -1172,4 +1199,54 @@ class BoschComCommoduleChargingStrategySelect(CoordinatorEntity, SelectEntity):
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._attr_current_option = self._read_value()
+        self.async_write_ha_state()
+
+
+# ===================================================================
+# Extra K40 selects (endpoints not yet in homecom_alt library)
+# ===================================================================
+
+
+class BoschComK40ExtraSelect(CoordinatorEntity, SelectEntity):
+    """Select entity backed by coordinator.extra_data with allowedValues."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        coordinator: BoschComModuleCoordinatorK40,
+        key: str,
+        translation_key: str,
+        unique_suffix: str,
+        allowed_values: list[str],
+    ) -> None:
+        """Initialize extra select entity."""
+        super().__init__(coordinator)
+        self._key = key
+        self._attr_translation_key = translation_key
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = f"{coordinator.unique_id}-{unique_suffix}"
+        self._attr_suggested_object_id = unique_suffix
+        self._attr_options = allowed_values
+
+    @property
+    def current_option(self) -> str | None:
+        """Return current value from extra_data."""
+        data = self.coordinator.extra_data.get(self._key)
+        if data and isinstance(data, dict):
+            return data.get("value")
+        return None
+
+    async def async_select_option(self, option: str) -> None:
+        """Set the option via PUT."""
+        await self.coordinator.async_put_extra_endpoint(self._key, option)
+        await self.coordinator.async_request_refresh()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data."""
+        data = self.coordinator.extra_data.get(self._key)
+        if data and isinstance(data, dict):
+            self._attr_current_option = data.get("value")
         self.async_write_ha_state()

--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -25,6 +25,7 @@ from homeassistant.const import (
     UnitOfTime,
     UnitOfVolume,
 )
+from homeassistant.core import callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -381,6 +382,70 @@ async def async_setup_entry(
             )
         except Exception:
             _LOGGER.exception("Failed to dump coordinator data for %s", devtype)
+
+    # K40 sensors from heat_sources (already fetched by homecom_alt bulk API)
+    for coordinator in coordinators:
+        if isinstance(coordinator, BoschComModuleCoordinatorK40):
+            hs = coordinator.data.heat_sources or {}
+            if hs.get("actualModulation"):
+                entities.append(
+                    BoschComK40ExtraSensor(
+                        coordinator,
+                        "actualModulation",
+                        "compressor_modulation",
+                        "compressor_modulation",
+                        native_unit="%",
+                    )
+                )
+            if hs.get("actualSupplyTemperature"):
+                entities.append(
+                    BoschComK40ExtraSensor(
+                        coordinator,
+                        "actualSupplyTemperature",
+                        "supply_temperature",
+                        "supply_temperature",
+                        device_class=SensorDeviceClass.TEMPERATURE,
+                        native_unit="°C",
+                    )
+                )
+            if hs.get("returnTemperature"):
+                entities.append(
+                    BoschComK40ExtraSensor(
+                        coordinator,
+                        "returnTemperature",
+                        "return_temperature",
+                        "return_temperature",
+                        device_class=SensorDeviceClass.TEMPERATURE,
+                        native_unit="°C",
+                    )
+                )
+            if hs.get("systemPressure"):
+                entities.append(
+                    BoschComK40ExtraSensor(
+                        coordinator,
+                        "systemPressure",
+                        "system_pressure",
+                        "system_pressure",
+                        device_class=SensorDeviceClass.PRESSURE,
+                        native_unit="bar",
+                    )
+                )
+            if hs.get("totalWorkingTime"):
+                entities.append(
+                    BoschComK40ExtraSensor(
+                        coordinator,
+                        "totalWorkingTime",
+                        "compressor_working_time",
+                        "compressor_working_time",
+                        device_class=SensorDeviceClass.DURATION,
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        native_unit="s",
+                    )
+                )
+            if hs.get("actualHeatDemand"):
+                entities.append(BoschComK40HeatDemandSensor(coordinator))
+            if hs.get("starts"):
+                entities.append(BoschComK40StartCountsSensor(coordinator))
 
     if entities:
         async_add_entities(entities)
@@ -3024,3 +3089,157 @@ def _build_wddw2_totals_sensors(
         )
 
     return entities
+
+
+# ===================================================================
+# Extra K40 sensors (endpoints not yet in homecom_alt library)
+# ===================================================================
+
+
+class BoschComK40ExtraSensor(CoordinatorEntity, SensorEntity):
+    """Sensor reading a float value from coordinator.extra_data."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        coordinator: BoschComModuleCoordinatorK40,
+        key: str,
+        translation_key: str,
+        unique_suffix: str,
+        device_class: SensorDeviceClass | None = None,
+        state_class: SensorStateClass | None = SensorStateClass.MEASUREMENT,
+        native_unit: str | None = None,
+        convert_seconds_to_hours: bool = False,
+    ) -> None:
+        """Initialize extra sensor."""
+        super().__init__(coordinator)
+        self._key = key
+        self._attr_translation_key = translation_key
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = f"{coordinator.unique_id}-{unique_suffix}"
+        self._attr_suggested_object_id = unique_suffix
+        self._attr_device_class = device_class
+        self._attr_state_class = state_class
+        self._attr_native_unit_of_measurement = native_unit
+        self._convert_s_to_h = convert_seconds_to_hours
+
+    @property
+    def native_value(self) -> float | int | None:
+        """Return current value."""
+        hs = self.coordinator.data.heat_sources or {}
+        data = hs.get(self._key)
+        if data and isinstance(data, dict):
+            val = data.get("value")
+            if val is not None and self._convert_s_to_h:
+                return round(val / 3600, 1)
+            # Return int for whole numbers (removes .0 display)
+            if val is not None and val == int(val):
+                return int(val)
+            return val
+        return None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data."""
+        hs = self.coordinator.data.heat_sources or {}
+        data = hs.get(self._key)
+        if data and isinstance(data, dict):
+            val = data.get("value")
+            if val is not None and self._convert_s_to_h:
+                self._attr_native_value = round(val / 3600, 1)
+            elif val is not None and val == int(val):
+                self._attr_native_value = int(val)
+            else:
+                self._attr_native_value = val
+        else:
+            self._attr_native_value = None
+        self.async_write_ha_state()
+
+
+class BoschComK40HeatDemandSensor(CoordinatorEntity, SensorEntity):
+    """Sensor for actualHeatDemand (what the compressor is doing)."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(self, coordinator: BoschComModuleCoordinatorK40) -> None:
+        """Initialize heat demand sensor."""
+        super().__init__(coordinator)
+        self._attr_translation_key = "heat_demand"
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = f"{coordinator.unique_id}-heat_demand"
+        self._attr_suggested_object_id = "heat_demand"
+        self._attr_device_class = SensorDeviceClass.ENUM
+        self._attr_options = ["idle", "ch", "dhw", "frost"]
+
+    @property
+    def native_value(self) -> str | None:
+        """Return current demand (first active or 'idle')."""
+        hs = self.coordinator.data.heat_sources or {}
+        data = hs.get("actualHeatDemand")
+        if data and isinstance(data, dict):
+            values = data.get("values", [])
+            active = [v for v in values if v]
+            return active[0] if active else "idle"
+        return None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data."""
+        hs = self.coordinator.data.heat_sources or {}
+        data = hs.get("actualHeatDemand")
+        if data and isinstance(data, dict):
+            values = data.get("values", [])
+            active = [v for v in values if v]
+            self._attr_native_value = active[0] if active else "idle"
+        else:
+            self._attr_native_value = None
+        self.async_write_ha_state()
+
+
+class BoschComK40StartCountsSensor(CoordinatorEntity, SensorEntity):
+    """Sensor for numberOfStarts (total with per-domain breakdown)."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(self, coordinator: BoschComModuleCoordinatorK40) -> None:
+        """Initialize start counts sensor."""
+        super().__init__(coordinator)
+        self._attr_translation_key = "compressor_starts"
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = f"{coordinator.unique_id}-compressor_starts"
+        self._attr_suggested_object_id = "compressor_starts"
+        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+        self._attr_native_unit_of_measurement = "starts"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return total starts."""
+        hs = self.coordinator.data.heat_sources or {}
+        data = hs.get("starts")
+        if data and isinstance(data, dict):
+            for entry in data.get("values", []):
+                if isinstance(entry, dict) and "total" in entry:
+                    return int(entry["total"])
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict | None:
+        """Return per-domain breakdown."""
+        hs = self.coordinator.data.heat_sources or {}
+        data = hs.get("starts")
+        if data and isinstance(data, dict):
+            attrs = {}
+            for entry in data.get("values", []):
+                if isinstance(entry, dict):
+                    attrs.update(entry)
+            return attrs if attrs else None
+        return None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data."""
+        self.async_write_ha_state()

--- a/custom_components/bosch_homecom/strings.json
+++ b/custom_components/bosch_homecom/strings.json
@@ -188,6 +188,22 @@
           "off": "Off"
         }
       },
+      "additional_heater_mode": {
+        "name": "Additional heater",
+        "state": {
+          "off": "Off",
+          "manual": "Manual",
+          "auto": "Auto"
+        }
+      },
+      "silent_mode": {
+        "name": "Silent mode",
+        "state": {
+          "off": "Off",
+          "auto": "Auto",
+          "on": "On"
+        }
+      },
       "hc_night_switch_mode": {
         "name": "{circuit} night switch mode"
       },
@@ -217,6 +233,33 @@
           "manual": "Manual",
           "auto": "Auto"
         }
+      },
+      "compressor_modulation": {
+        "name": "Compressor modulation"
+      },
+      "supply_temperature": {
+        "name": "Supply temperature"
+      },
+      "return_temperature": {
+        "name": "Return temperature"
+      },
+      "system_pressure": {
+        "name": "System pressure"
+      },
+      "compressor_working_time": {
+        "name": "Compressor working time"
+      },
+      "heat_demand": {
+        "name": "Heat demand",
+        "state": {
+          "idle": "Idle",
+          "ch": "Central heating",
+          "dhw": "Domestic hot water",
+          "frost": "Frost protection"
+        }
+      },
+      "compressor_starts": {
+        "name": "Compressor starts"
       },
       "indoor_humidity": {
         "name": "Indoor Humidity"
@@ -320,6 +363,9 @@
       },
       "ventilation_summer_duration": {
         "name": "{zone} summer bypass duration"
+      },
+      "dhw_charge_duration": {
+        "name": "DHW charge duration"
       }
     },
     "button": {
@@ -331,6 +377,9 @@
       },
       "wb_pause_charging": {
         "name": "Pause Charging"
+      },
+      "dhw_extra_charge": {
+        "name": "Extra hot water"
       }
     },
     "switch": {

--- a/custom_components/bosch_homecom/translations/de.json
+++ b/custom_components/bosch_homecom/translations/de.json
@@ -208,6 +208,22 @@
           "default": "Standard",
           "solar-eco": "Solar-Eco"
         }
+      },
+      "additional_heater_mode": {
+        "name": "Elektrischer Zuheizer",
+        "state": {
+          "off": "Aus",
+          "manual": "Manuell",
+          "auto": "Automatik"
+        }
+      },
+      "silent_mode": {
+        "name": "Flüstermodus",
+        "state": {
+          "off": "Aus",
+          "auto": "Automatik",
+          "on": "An"
+        }
       }
     },
     "sensor": {
@@ -302,6 +318,33 @@
       },
       "energy_history_hourly": {
         "name": "Energieverlauf (stündlich)"
+      },
+      "compressor_modulation": {
+        "name": "Kompressor Modulation"
+      },
+      "supply_temperature": {
+        "name": "Vorlauftemperatur"
+      },
+      "return_temperature": {
+        "name": "Rücklauftemperatur"
+      },
+      "system_pressure": {
+        "name": "Systemdruck"
+      },
+      "compressor_working_time": {
+        "name": "Kompressor Laufzeit"
+      },
+      "heat_demand": {
+        "name": "Wärmebedarf",
+        "state": {
+          "idle": "Aus",
+          "ch": "Heizung",
+          "dhw": "Warmwasser",
+          "frost": "Frostschutz"
+        }
+      },
+      "compressor_starts": {
+        "name": "Kompressor Starts"
       }
     },
     "binary_sensor": {
@@ -321,6 +364,9 @@
       },
       "ventilation_summer_duration": {
         "name": "{zone} Sommer-Bypass Dauer"
+      },
+      "dhw_charge_duration": {
+        "name": "Warmwasser Ladedauer"
       }
     },
     "button": {
@@ -332,6 +378,9 @@
       },
       "wb_pause_charging": {
         "name": "Laden pausieren"
+      },
+      "dhw_extra_charge": {
+        "name": "Extra Warmwasser"
       }
     },
     "switch": {

--- a/custom_components/bosch_homecom/translations/en.json
+++ b/custom_components/bosch_homecom/translations/en.json
@@ -206,6 +206,22 @@
           "default": "Default",
           "solar-eco": "Solar Eco"
         }
+      },
+      "additional_heater_mode": {
+        "name": "Additional heater",
+        "state": {
+          "off": "Off",
+          "manual": "Manual",
+          "auto": "Auto"
+        }
+      },
+      "silent_mode": {
+        "name": "Silent mode",
+        "state": {
+          "off": "Off",
+          "auto": "Auto",
+          "on": "On"
+        }
       }
     },
     "sensor": {
@@ -300,6 +316,33 @@
       },
       "energy_history_hourly": {
         "name": "Energy history (hourly)"
+      },
+      "compressor_modulation": {
+        "name": "Compressor modulation"
+      },
+      "supply_temperature": {
+        "name": "Supply temperature"
+      },
+      "return_temperature": {
+        "name": "Return temperature"
+      },
+      "system_pressure": {
+        "name": "System pressure"
+      },
+      "compressor_working_time": {
+        "name": "Compressor working time"
+      },
+      "heat_demand": {
+        "name": "Heat demand",
+        "state": {
+          "idle": "Idle",
+          "ch": "Central heating",
+          "dhw": "Domestic hot water",
+          "frost": "Frost protection"
+        }
+      },
+      "compressor_starts": {
+        "name": "Compressor starts"
       }
     },
     "binary_sensor": {
@@ -319,6 +362,9 @@
       },
       "ventilation_summer_duration": {
         "name": "{zone} summer bypass duration"
+      },
+      "dhw_charge_duration": {
+        "name": "DHW charge duration"
       }
     },
     "button": {
@@ -330,6 +376,9 @@
       },
       "wb_pause_charging": {
         "name": "Pause Charging"
+      },
+      "dhw_extra_charge": {
+        "name": "Extra hot water"
       }
     },
     "switch": {

--- a/custom_components/bosch_homecom/translations/nl.json
+++ b/custom_components/bosch_homecom/translations/nl.json
@@ -206,6 +206,22 @@
           "default": "Standaard",
           "solar-eco": "Solar-Eco"
         }
+      },
+      "additional_heater_mode": {
+        "name": "Elektrische bijverwarming",
+        "state": {
+          "off": "Uit",
+          "manual": "Handmatig",
+          "auto": "Automatisch"
+        }
+      },
+      "silent_mode": {
+        "name": "Stille modus",
+        "state": {
+          "off": "Uit",
+          "auto": "Automatisch",
+          "on": "Aan"
+        }
       }
     },
     "sensor": {
@@ -300,6 +316,33 @@
       },
       "energy_history_hourly": {
         "name": "Energiegeschiedenis (uurlijks)"
+      },
+      "compressor_modulation": {
+        "name": "Compressor modulatie"
+      },
+      "supply_temperature": {
+        "name": "Aanvoertemperatuur"
+      },
+      "return_temperature": {
+        "name": "Retourtemperatuur"
+      },
+      "system_pressure": {
+        "name": "Systeemdruk"
+      },
+      "compressor_working_time": {
+        "name": "Compressor looptijd"
+      },
+      "heat_demand": {
+        "name": "Warmtevraag",
+        "state": {
+          "idle": "Uit",
+          "ch": "Verwarming",
+          "dhw": "Warm water",
+          "frost": "Vorstbeveiliging"
+        }
+      },
+      "compressor_starts": {
+        "name": "Compressor starts"
       }
     },
     "binary_sensor": {
@@ -319,6 +362,9 @@
       },
       "ventilation_summer_duration": {
         "name": "{zone} zomerbypass duur"
+      },
+      "dhw_charge_duration": {
+        "name": "Warm water laadduur"
       }
     },
     "button": {
@@ -330,6 +376,9 @@
       },
       "wb_pause_charging": {
         "name": "Laden pauzeren"
+      },
+      "dhw_extra_charge": {
+        "name": "Extra warm water"
       }
     },
     "switch": {

--- a/tests/test_extra_entities.py
+++ b/tests/test_extra_entities.py
@@ -1,0 +1,421 @@
+"""Tests for extra K40 endpoint entities (sensor, select, button, number)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from homecom_alt import BHCDeviceK40
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bosch_homecom.button import BoschComK40DhwChargeButton
+from custom_components.bosch_homecom.const import CONF_DEVICES, CONF_REFRESH, DOMAIN
+from custom_components.bosch_homecom.coordinator import BoschComModuleCoordinatorK40
+from custom_components.bosch_homecom.number import BoschComK40DhwChargeDurationNumber
+from custom_components.bosch_homecom.select import BoschComK40ExtraSelect
+from custom_components.bosch_homecom.sensor import (
+    BoschComK40ExtraSensor,
+    BoschComK40HeatDemandSensor,
+    BoschComK40StartCountsSensor,
+)
+
+
+@pytest.fixture
+def device():
+    """Fixture for K40 device data."""
+    return {"deviceId": "102128202", "deviceType": "k40"}
+
+
+@pytest.fixture
+def firmware():
+    """Fixture for firmware data."""
+    return {"value": "14.00.03"}
+
+
+@pytest.fixture
+def entry():
+    """Fixture for config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="test-user",
+        unique_id="test-user",
+        data={
+            CONF_DEVICES: {"102128202_k40": True},
+            CONF_REFRESH: "mock_refresh",
+            "token": "mock_token",
+            "username": "test-user",
+            "code": "valid_code",
+        },
+    )
+
+
+def _make_k40_data():
+    """Create a minimal BHCDeviceK40."""
+    fields = BHCDeviceK40.__dataclass_fields__
+    kwargs = {
+        "device": "102128202",
+        "firmware": [],
+        "notifications": [],
+        "holiday_mode": {},
+        "away_mode": {},
+        "power_limitation": {},
+        "outdoor_temp": {},
+        "heat_sources": {},
+        "dhw_circuits": {},
+        "heating_circuits": {},
+        "ventilation": {},
+        "zones": {},
+        "flame_indication": {},
+        "energy_history": {},
+        "indoor_humidity": {},
+        "devices": {},
+    }
+    for optional in ("hourly_energy_history", "energy_gas_unit"):
+        if optional in fields:
+            kwargs[optional] = {}
+    return BHCDeviceK40(**kwargs)
+
+
+SAMPLE_EXTRA_DATA = {
+    "additional_heater": {
+        "id": "/heatSources/additionalHeater/operationMode",
+        "type": "stringValue",
+        "writeable": 1,
+        "value": "auto",
+        "allowedValues": ["off", "manual", "auto"],
+    },
+    "silent_mode": {
+        "id": "/system/silentMode/enabled",
+        "type": "stringValue",
+        "writeable": 1,
+        "value": "off",
+        "allowedValues": ["off", "auto", "on"],
+    },
+    "dhw_charge": {
+        "id": "/dhwCircuits/dhw1/charge",
+        "type": "stringValue",
+        "writeable": 1,
+        "value": "stop",
+        "allowedValues": ["start", "stop"],
+    },
+    "dhw_charge_duration": {
+        "id": "/dhwCircuits/dhw1/chargeDuration",
+        "type": "floatValue",
+        "writeable": 1,
+        "value": 60.0,
+        "unitOfMeasure": "mins",
+        "minValue": 60.0,
+        "maxValue": 2880.0,
+    },
+    "heat_demand": {
+        "id": "/heatSources/actualHeatDemand",
+        "type": "arrayData",
+        "writeable": 0,
+        "allowedValues": ["", "ch", "dhw", "frost"],
+        "values": ["dhw"],
+    },
+    "modulation": {
+        "id": "/heatSources/actualModulation",
+        "type": "floatValue",
+        "writeable": 0,
+        "value": 45.0,
+        "unitOfMeasure": "%",
+    },
+    "supply_temp": {
+        "id": "/heatSources/actualSupplyTemperature",
+        "type": "floatValue",
+        "writeable": 0,
+        "value": 41.8,
+        "unitOfMeasure": "C",
+    },
+    "return_temp": {
+        "id": "/heatSources/returnTemperature",
+        "type": "floatValue",
+        "writeable": 0,
+        "value": 40.0,
+        "unitOfMeasure": "C",
+    },
+    "system_pressure": {
+        "id": "/heatSources/systemPressure",
+        "type": "floatValue",
+        "writeable": 0,
+        "value": 1.8,
+        "unitOfMeasure": "bar",
+    },
+    "working_time": {
+        "id": "/heatSources/workingTime/totalSystem",
+        "type": "floatValue",
+        "writeable": 0,
+        "value": 6677759.0,
+        "unitOfMeasure": "s",
+    },
+    "number_of_starts": {
+        "id": "/heatSources/hs1/numberOfStarts",
+        "type": "emonValue",
+        "writeable": 0,
+        "values": [{"ch": 149.0}, {"dhw": 47.0}, {"cooling": 0.0}, {"total": 196.0}],
+    },
+}
+
+
+SAMPLE_HEAT_SOURCES = {
+    "actualModulation": {"value": 45.0, "unitOfMeasure": "%"},
+    "actualSupplyTemperature": {"value": 41.8, "unitOfMeasure": "C"},
+    "returnTemperature": {"value": 40.0, "unitOfMeasure": "C"},
+    "systemPressure": {"value": 1.8, "unitOfMeasure": "bar"},
+    "totalWorkingTime": {"value": 6677759.0, "unitOfMeasure": "s"},
+    "actualHeatDemand": {
+        "allowedValues": ["", "ch", "dhw", "frost"],
+        "values": ["dhw"],
+    },
+    "starts": {
+        "values": [{"ch": 149.0}, {"dhw": 47.0}, {"cooling": 0.0}, {"total": 196.0}],
+    },
+}
+
+
+def _mock_coordinator(extra_data=None, heat_sources=None):
+    """Create a mock K40 coordinator with heat_sources and extra_data."""
+
+    class _Data:
+        def __init__(self, hs, dhw):
+            self.heat_sources = hs
+            self.device = {"deviceId": "102128202", "deviceType": "k40"}
+            self.dhw_circuits = dhw
+
+    coordinator = MagicMock()
+    coordinator.unique_id = "102128202"
+    coordinator.device_info = {"identifiers": {("bosch_homecom", "102128202")}}
+    coordinator.extra_data = extra_data if extra_data is not None else SAMPLE_EXTRA_DATA
+    coordinator.data = _Data(
+        hs=heat_sources if heat_sources is not None else SAMPLE_HEAT_SOURCES,
+        dhw=[{"id": "/dhwCircuits/dhw1", "chargeDuration": {"value": 60.0}}],
+    )
+    coordinator.bhc = MagicMock()
+    coordinator.bhc.async_set_dhw_charge = AsyncMock()
+    coordinator.bhc.async_set_dhw_charge_duration = AsyncMock()
+    coordinator.async_put_extra_endpoint = AsyncMock()
+    coordinator.async_request_refresh = AsyncMock()
+    return coordinator
+
+
+# ===================================================================
+# Coordinator tests
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_k40_coordinator_fetches_extra_endpoints(hass, entry, device, firmware):
+    """Test that K40 coordinator fetches all extra endpoints."""
+    entry.add_to_hass(hass)
+    bhc = MagicMock()
+    bhc.get_token = AsyncMock()
+    bhc.async_update = AsyncMock(return_value=_make_k40_data())
+    bhc.async_action_universal_get = AsyncMock(return_value={"value": "test"})
+
+    coordinator = BoschComModuleCoordinatorK40(
+        hass, bhc, device, firmware, entry, auth_provider=False
+    )
+    await coordinator._async_update_data()
+
+    # Should have called universal_get for each extra endpoint
+    assert bhc.async_action_universal_get.call_count == len(
+        BoschComModuleCoordinatorK40.EXTRA_ENDPOINTS
+    )
+    # All keys should be in extra_data
+    for key in BoschComModuleCoordinatorK40.EXTRA_ENDPOINTS:
+        assert key in coordinator.extra_data
+
+
+@pytest.mark.asyncio
+async def test_k40_coordinator_extra_endpoint_failure_graceful(
+    hass, entry, device, firmware
+):
+    """Test that a failing endpoint doesn't crash the update."""
+    entry.add_to_hass(hass)
+    bhc = MagicMock()
+    bhc.get_token = AsyncMock()
+    bhc.async_update = AsyncMock(return_value=_make_k40_data())
+    bhc.async_action_universal_get = AsyncMock(side_effect=Exception("timeout"))
+
+    coordinator = BoschComModuleCoordinatorK40(
+        hass, bhc, device, firmware, entry, auth_provider=False
+    )
+    data = await coordinator._async_update_data()
+
+    # Should not crash
+    assert data is not None
+    # All keys should be None
+    for key in BoschComModuleCoordinatorK40.EXTRA_ENDPOINTS:
+        assert coordinator.extra_data[key] is None
+
+
+@pytest.mark.asyncio
+async def test_k40_coordinator_put_extra_endpoint(hass, entry, device, firmware):
+    """Test PUT to an extra endpoint."""
+    entry.add_to_hass(hass)
+    bhc = MagicMock()
+    bhc.get_token = AsyncMock()
+    bhc.async_update = AsyncMock(return_value=_make_k40_data())
+    bhc.async_action_universal_get = AsyncMock(return_value={})
+    bhc._async_http_request = AsyncMock()
+
+    coordinator = BoschComModuleCoordinatorK40(
+        hass, bhc, device, firmware, entry, auth_provider=False
+    )
+    await coordinator.async_put_extra_endpoint("silent_mode", "on")
+
+    bhc.get_token.assert_awaited()
+    bhc._async_http_request.assert_awaited_once()
+    args = bhc._async_http_request.call_args[0]
+    assert args[0] == "put"
+    assert "silentMode/enabled" in args[1]
+    assert args[2] == {"value": "on"}
+
+
+# ===================================================================
+# Sensor entity tests
+# ===================================================================
+
+
+def test_float_sensor_value():
+    """Test BoschComK40ExtraSensor returns correct value."""
+    coordinator = _mock_coordinator()
+    sensor = BoschComK40ExtraSensor(
+        coordinator,
+        "actualModulation",
+        "compressor_modulation",
+        "compressor_modulation",
+    )
+    assert sensor.native_value == 45.0
+
+
+def test_float_sensor_none_when_no_data():
+    """Test BoschComK40ExtraSensor returns None when no data."""
+    coordinator = _mock_coordinator(heat_sources={"actualModulation": None})
+    sensor = BoschComK40ExtraSensor(
+        coordinator,
+        "actualModulation",
+        "compressor_modulation",
+        "compressor_modulation",
+    )
+    assert sensor.native_value is None
+
+
+def test_heat_demand_sensor_active():
+    """Test heat demand sensor shows active demand."""
+    coordinator = _mock_coordinator()
+    sensor = BoschComK40HeatDemandSensor(coordinator)
+    assert sensor.native_value == "dhw"
+
+
+def test_heat_demand_sensor_idle():
+    """Test heat demand sensor shows idle when no demand."""
+    hs = dict(SAMPLE_HEAT_SOURCES)
+    hs["actualHeatDemand"] = {"values": [""]}
+    coordinator = _mock_coordinator(heat_sources=hs)
+    sensor = BoschComK40HeatDemandSensor(coordinator)
+    assert sensor.native_value == "idle"
+
+
+def test_start_counts_sensor():
+    """Test start counts sensor returns total."""
+    coordinator = _mock_coordinator()
+    sensor = BoschComK40StartCountsSensor(coordinator)
+    assert sensor.native_value == 196.0
+
+
+def test_start_counts_attributes():
+    """Test start counts sensor has per-domain attributes."""
+    coordinator = _mock_coordinator()
+    sensor = BoschComK40StartCountsSensor(coordinator)
+    attrs = sensor.extra_state_attributes
+    assert attrs["ch"] == 149.0
+    assert attrs["dhw"] == 47.0
+    assert attrs["total"] == 196.0
+
+
+# ===================================================================
+# Select entity tests
+# ===================================================================
+
+
+def test_extra_select_current_option():
+    """Test BoschComK40ExtraSelect returns current value."""
+    coordinator = _mock_coordinator()
+    select = BoschComK40ExtraSelect(
+        coordinator,
+        "silent_mode",
+        "silent_mode",
+        "silent_mode",
+        ["off", "auto", "on"],
+    )
+    assert select.current_option == "off"
+
+
+@pytest.mark.asyncio
+async def test_extra_select_set_option():
+    """Test BoschComK40ExtraSelect calls PUT on select."""
+    coordinator = _mock_coordinator()
+    select = BoschComK40ExtraSelect(
+        coordinator,
+        "silent_mode",
+        "silent_mode",
+        "silent_mode",
+        ["off", "auto", "on"],
+    )
+    await select.async_select_option("on")
+
+    coordinator.async_put_extra_endpoint.assert_awaited_once_with("silent_mode", "on")
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+# ===================================================================
+# Button entity tests
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_dhw_charge_button_press():
+    """Test DHW charge button sends start command."""
+    coordinator = _mock_coordinator()
+    button = BoschComK40DhwChargeButton(coordinator)
+    await button.async_press()
+
+    coordinator.bhc.async_set_dhw_charge.assert_awaited_once_with(
+        "102128202", "dhw1", "start"
+    )
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+# ===================================================================
+# Number entity tests
+# ===================================================================
+
+
+def test_dhw_charge_duration_value():
+    """Test DHW charge duration number returns correct value."""
+    coordinator = _mock_coordinator()
+    number = BoschComK40DhwChargeDurationNumber(coordinator)
+    assert number.native_value == 60.0
+
+
+@pytest.mark.asyncio
+async def test_dhw_charge_duration_set_value():
+    """Test DHW charge duration number sets value via library method."""
+    coordinator = _mock_coordinator()
+    number = BoschComK40DhwChargeDurationNumber(coordinator)
+    await number.async_set_native_value(120.0)
+
+    coordinator.bhc.async_set_dhw_charge_duration.assert_awaited_once_with(
+        "102128202", "dhw1", "120"
+    )
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+def test_dhw_charge_duration_limits():
+    """Test DHW charge duration has correct min/max."""
+    coordinator = _mock_coordinator()
+    number = BoschComK40DhwChargeDurationNumber(coordinator)
+    assert number._attr_native_min_value == 60
+    assert number._attr_native_max_value == 2880


### PR DESCRIPTION
## Summary

Add 11 new entities for K40/K30/ICOM devices exposing heat source data, DHW controls, and system settings.

## New Entities

### Sensors (from `coordinator.data.heat_sources` — no extra API calls)

| Entity | Value example | Notes |
|--------|--------------|-------|
| Compressor modulation | 0 % | 0 when idle, >0 when running |
| Supply temperature | 37.1 °C | Flow temperature |
| Return temperature | 35.6 °C | |
| System pressure | 1.8 bar | |
| Compressor working time | 6677640 s | total_increasing, device_class=duration |
| Heat demand | idle / ch / dhw / frost | Enum — direct compressor activity indicator |
| Compressor starts | 196 | total_increasing, per-domain breakdown in attributes (ch/dhw/cooling) |

### Selects (from `coordinator.extra_data` — fetched via universal_get)

| Entity | Options | Notes |
|--------|---------|-------|
| Additional heater | off / manual / auto | Elektrischer Zuheizer |
| Silent mode | off / auto / on | Night quiet mode |

### Button

| Entity | Action |
|--------|--------|
| Extra hot water | Triggers one-time DHW charge via `async_set_dhw_charge` |

### Number

| Entity | Range | Notes |
|--------|-------|-------|
| DHW charge duration | 60–2880 min | Read via extra_data, write via `async_set_dhw_charge_duration` |

## Implementation

- **coordinator.py**: `EXTRA_ENDPOINTS` fetches only additionalHeater, silentMode, and dhwChargeDuration (not in homecom_alt bulk fetch). All 7 sensors read from the existing `heat_sources` dict that the library already bulk-fetches — zero additional API calls.
- Entity classes in their standard platform files following existing CoordinatorEntity patterns.
- Float values from the API that are whole numbers are cast to int for cleaner display (no `.0`).
- Full translations (en/de/nl).
- 15 new tests. All 81 pass, lint clean.

## Dependency

> ⚠️ The additionalHeater and silentMode selects use `async_put_extra_endpoint()` as a temporary bridge.

A corresponding PR for `homecom_alt` has been submitted: https://github.com/serbanb11/homecom_alt/pull/95

Once that library PR is merged and released, these can be migrated to use the proper library methods.

## Testing

**Confirmed on real hardware** — Bosch Compress CS5800iAW 12 (K40, gateway firmware 14.00.03):

- ✅ All 11 entities appear correctly after restart
- ✅ All 7 sensors read correct values from `heat_sources`
- ✅ Both selects read their current values (additionalHeater=auto, silentMode=off)
- ✅ DHW charge duration reads 60 min
- ✅ Extra hot water button present (triggers `async_set_dhw_charge`)
- ✅ Write confirmed working (tested DHW operation mode eco↔ownprogram round-trip)
- ✅ No errors in HA logs related to these changes
- ✅ Unit tests pass (81 total), lint clean
