### PR TITLE
Add get_recordings_service to fetch /recordings/* via bulk POST

### DIFF
--- a/custom_components/bosch_homecom/__init__.py
+++ b/custom_components/bosch_homecom/__init__.py
@@ -357,5 +357,37 @@ async def async_setup(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         supports_response=SupportsResponse.ONLY,
     )
 
+    async def get_recordings_service(call: ServiceCall) -> ServiceResponse:
+        """Service to fetch /recordings/* endpoints via bulk POST.
+
+        The single-endpoint universal GET returns empty for /recordings/*
+        (that tier is only exposed via POST /pointt-api/api/v1/bulk).
+        Reuses async_request_bulk from homecom_alt.
+        """
+        device_id = str(call.data.get("device_id"))
+        coordinator = _find_coordinator_by_device_id(hass, device_id)
+        if coordinator is None:
+            _LOGGER.error("Coordinator not found for device %s", device_id)
+            return {}
+        paths = call.data.get("paths")
+        if paths is None:
+            _LOGGER.error("Missing paths argument")
+            return {}
+        if isinstance(paths, str):
+            paths = [paths]
+        if not isinstance(paths, list) or not paths:
+            _LOGGER.error("paths must be a non-empty list of strings")
+            return {}
+        result = await coordinator.bhc.async_request_bulk(device_id, paths)
+        return result or {}
+
+    # Register our service with Home Assistant.
+    hass.services.async_register(
+        DOMAIN,
+        "get_recordings_service",
+        get_recordings_service,
+        supports_response=SupportsResponse.ONLY,
+    )
+
     # Return boolean to indicate that initialization was successfully.
     return True

--- a/custom_components/bosch_homecom/services.yaml
+++ b/custom_components/bosch_homecom/services.yaml
@@ -74,3 +74,29 @@ get_custom_path_service:
       required: true
       default: "/resource/notifications"
       example: "/resource/notifications"
+
+get_recordings_service:
+  name: Fetch Recording Endpoints
+  description: >-
+    Fetch /recordings/* endpoints via bulk POST (the single-endpoint universal
+    GET returns empty for /recordings/*, that tier is only exposed via POST
+    /pointt-api/api/v1/bulk). Use this to fetch daily energy/recording data
+    like emon totals and ventilation heat recovery.
+  fields:
+    device_id:
+      name: device_id
+      description: The device id to fetch data from
+      required: true
+      default: "100000000"
+      example: "100000000"
+    paths:
+      name: paths
+      description: >-
+        List of /recordings paths. Each path may include a ?interval=YYYY-MM-DD
+        query string. Max 30 per call (auto-chunked).
+      required: true
+      example: |
+        - /recordings/heatSources/emon/ventilation/heatRecovered?interval=2026-07-06
+        - /recordings/heatSources/emon/total/outputProduced?interval=2026-07-06
+      selector:
+        object:


### PR DESCRIPTION
## Motivation

The existing `get_custom_path_service` uses a single-endpoint GET which returns empty for `/recordings/*` paths — that tier is only exposed via `POST /pointt-api/api/v1/bulk` (as documented by @serbanb11 in [issue #61](https://github.com/serbanb11/bosch-homecom-hass/issues/61#issuecomment-3580212401)).

`homecom_alt.async_request_bulk` already implements that POST correctly (auto-chunking, refEnum-aware, log-level tuning per #143), but no HA service was wired up to expose it. Result: end users can't reach the energy time-series recordings via HA actions.

## Change

Adds `bosch_homecom.get_recordings_service` as a thin wrapper around the existing library method. Accepts a list of paths, returns `{path: payload}`.

**Diff summary:**
- `__init__.py`: +32 lines (service definition + registration)
- `services.yaml`: +28 lines (service metadata + example)
- No new deps, no lib changes, no sensor additions — deliberately minimal.

## Usage

```yaml
action: bosch_homecom.get_recordings_service
data:
  device_id: "XXXXXXXXX"
  paths:
    - /recordings/heatSources/emon/total/ventilation?interval=2026-07-06
    - /recordings/heatSources/emon/ventilation/heatRecovered?interval=2026-07-06
```

Response is the raw bulk payload dict keyed by path. Non-OK endpoints are logged and filtered by the existing library helper.

## Verified endpoints (K40 — Bosch Compress 5800iAW)

All discovered via refEnum lookup at `GET /resource/recordings/heatSources/emon` and its children, then confirmed with real `?interval=YYYY-MM-DD` calls returning `{sampleRate: P1H, recording: [{y, c}, ...]}`:

| Path | Content | Unit |
|---|---|---|
| `emon/total/compressor` | Compressor electricity total | kWh |
| `emon/total/eheater` | Electric heater electricity total | kWh |
| `emon/total/ventilation` | Ventilation electricity total | kWh |
| `emon/total/outputProduced` | Heat produced total | kWh |
| `emon/ch/{compressor,eheater,outputProduced}` | Central heating breakdown | kWh |
| `emon/dhw/{compressor,eheater,outputProduced}` | DHW breakdown | kWh |
| `emon/cooling/{compressor,outputProduced}` | Cooling breakdown (no eheater — physically impossible) | kWh |
| `emon/ventilation/heatRecovered` | Heat recovered by enthalpy exchanger | kWh |

The Bosch HomeCom app's "Energy Monitoring" view is built on exactly these endpoints (matches the "verbrauchte Energie / Wärmerückgewinnung" breakdown per Wärmepumpe / Lüftung menus).

Sample call for verification (my device, 2026-07-06):
- `emon/total/compressor` = 4.15 kWh (matches app)
- `emon/total/ventilation` = 0.98 kWh (~40 W continuous fan)
- `emon/total/outputProduced` = 11.29 kWh (three DHW peaks)

## Non-goals for this PR

- No native sensors — kept scope tight so review is straightforward
- No LTS backfill script — users can build one on top (I'll open a follow-up issue asking if a native-sensor PR is welcome, since I need to build one for my own setup anyway)
- No lib changes — everything here rides on existing `async_request_bulk`

## Testing

Manually tested on K40 hardware (Bosch Compress 5800iAW):
- Empty `paths` → clean error log, no crash
- Single path as string → auto-wrapped into list, works
- 30+ paths → library auto-chunks, works
- 404 paths → filtered out by `_log_endpoint_status` (existing behavior)
- Response accessible via HA Developer Tools → Actions with `Antwort erfassen`