### PR TITLE
Add K40 energy recordings sensors (13 sensors from /recordings/emon/*)

### DIFF
--- a/custom_components/bosch_homecom/coordinator.py
+++ b/custom_components/bosch_homecom/coordinator.py
@@ -307,12 +307,19 @@ class _K40ExtraEndpointsMixin:
             for item in recording:
                 if not isinstance(item, dict):
                     continue
-                y = item.get("y")
                 c = item.get("c")
+                # Skip future / unpopulated hour slots. Some devices (e.g.
+                # Buderus Logatherm WLW166i) return {"c": 0, "y": 1.0} for
+                # every not-yet-populated hour of the current day; without
+                # this guard both ``sum`` and ``avg`` aggregations would
+                # count those placeholders as real samples. Reported by
+                # @ombuyse in PR #155.
+                if not isinstance(c, (int, float)) or c <= 0:
+                    continue
+                y = item.get("y")
                 if isinstance(y, (int, float)):
                     y_sum += y
-                if isinstance(c, (int, float)):
-                    c_sum += int(c)
+                c_sum += int(c)
             if meta["agg"] == "avg":
                 if c_sum > 0:
                     self.recordings[meta["key"]] = round(y_sum / c_sum, 2)

--- a/custom_components/bosch_homecom/coordinator.py
+++ b/custom_components/bosch_homecom/coordinator.py
@@ -277,11 +277,17 @@ class _K40ExtraEndpointsMixin:
             RetryError,
             TimeoutError,
         ):
+            # Transport failure — don't set the timestamp so the next regular
+            # coordinator tick retries immediately.
             _LOGGER.debug(
                 "Device %s: recordings fetch failed, keeping last values",
                 self.unique_id,
             )
             return
+
+        # HTTP call succeeded (even if empty) — mark the tick to enforce the
+        # rate-limit for the next hour regardless of payload contents.
+        self._last_recordings_fetch = now
 
         if not result:
             return
@@ -312,8 +318,6 @@ class _K40ExtraEndpointsMixin:
                     self.recordings[meta["key"]] = round(y_sum / c_sum, 2)
             else:  # "sum"
                 self.recordings[meta["key"]] = round(y_sum, 3)
-
-        self._last_recordings_fetch = now
 
 
 class BoschComModuleCoordinatorK40(

--- a/custom_components/bosch_homecom/coordinator.py
+++ b/custom_components/bosch_homecom/coordinator.py
@@ -146,27 +146,42 @@ class BoschComModuleCoordinatorRac(BoschComModuleCoordinatorBase[BHCDeviceRac]):
         )
 
 
-ENERGY_RECORDINGS_POLL_INTERVAL = timedelta(hours=1)
+RECORDINGS_POLL_INTERVAL = timedelta(hours=1)
 
-# Maps (path_suffix under /recordings/heatSources/emon/) -> local key stored
-# in coordinator.energy_recordings. Discovered via refEnum browsability at
-# GET /resource/recordings/heatSources/emon on a K40 (Bosch Compress 5800iAW).
-# Endpoints the device does not support silently drop out of the bulk response
-# (existing _log_endpoint_status handling) and the previous good value is kept.
-ENERGY_RECORDING_PATHS: dict[str, str] = {
-    "total/compressor": "energy_compressor_total",
-    "total/eheater": "energy_eheater_total",
-    "total/ventilation": "energy_ventilation_total",
-    "total/outputProduced": "heat_produced_total",
-    "ventilation/heatRecovered": "heat_recovered_ventilation",
-    "ch/compressor": "energy_compressor_ch",
-    "ch/eheater": "energy_eheater_ch",
-    "ch/outputProduced": "heat_produced_ch",
-    "dhw/compressor": "energy_compressor_dhw",
-    "dhw/eheater": "energy_eheater_dhw",
-    "dhw/outputProduced": "heat_produced_dhw",
-    "cooling/compressor": "energy_compressor_cooling",
-    "cooling/outputProduced": "heat_produced_cooling",
+# Maps (path_suffix under /recordings/heatSources/) -> {key, agg} for the
+# local coordinator.recordings dict. Discovered via refEnum browsability
+# at GET /resource/recordings/heatSources on a K40 (Bosch Compress 5800iAW).
+# Endpoints the device does not support silently drop out of the bulk
+# response (existing _log_endpoint_status handling) and the previous good
+# value is kept.
+#
+# ``agg`` selects the aggregation of the hourly bucket values:
+#   ``sum`` -> sum of ``y`` values (Bosch's kWh energy counters, c=1 each).
+#   ``avg`` -> ``sum(y) / sum(c)``. Bosch stores some sensor recordings as
+#             per-hour sample-sums; the count is the number of samples that
+#             went into the sum. Used for temperature time-series such as
+#             ``actualSupplyTemperature``.
+RECORDING_PATHS: dict[str, dict] = {
+    # Energy counters — /recordings/heatSources/emon/*, unit kWh
+    "emon/total/compressor": {"key": "energy_compressor_total", "agg": "sum"},
+    "emon/total/eheater": {"key": "energy_eheater_total", "agg": "sum"},
+    "emon/total/ventilation": {"key": "energy_ventilation_total", "agg": "sum"},
+    "emon/total/outputProduced": {"key": "heat_produced_total", "agg": "sum"},
+    "emon/ventilation/heatRecovered": {
+        "key": "heat_recovered_ventilation",
+        "agg": "sum",
+    },
+    "emon/ch/compressor": {"key": "energy_compressor_ch", "agg": "sum"},
+    "emon/ch/eheater": {"key": "energy_eheater_ch", "agg": "sum"},
+    "emon/ch/outputProduced": {"key": "heat_produced_ch", "agg": "sum"},
+    "emon/dhw/compressor": {"key": "energy_compressor_dhw", "agg": "sum"},
+    "emon/dhw/eheater": {"key": "energy_eheater_dhw", "agg": "sum"},
+    "emon/dhw/outputProduced": {"key": "heat_produced_dhw", "agg": "sum"},
+    "emon/cooling/compressor": {"key": "energy_compressor_cooling", "agg": "sum"},
+    "emon/cooling/outputProduced": {"key": "heat_produced_cooling", "agg": "sum"},
+    # Sensor time-series — direct leaves under /recordings/heatSources/*,
+    # per-hour sample-sum with count -> averaging.
+    "actualSupplyTemperature": {"key": "supply_temp_avg_today", "agg": "avg"},
 }
 
 
@@ -179,12 +194,13 @@ class _K40ExtraEndpointsMixin:
     K40 and ICOM coordinators. Endpoints the device does not support resolve to
     ``None`` and simply produce no entity.
 
-    Also fetches the ``/recordings/heatSources/emon/*`` energy time-series at a
-    slower cadence (see ENERGY_RECORDINGS_POLL_INTERVAL) and caches per-path
-    cumulative-today values in ``energy_recordings``. On network or per-endpoint
-    failures the previous good value is kept — the sensors thus stay flat at
-    their last good number rather than resetting to zero, which would trip HA's
-    ``total_increasing`` reset detection.
+    Also fetches the ``/recordings/heatSources/*`` time-series (energy under
+    ``/emon/*`` and sensor averages such as ``actualSupplyTemperature``) at a
+    slower cadence (see RECORDINGS_POLL_INTERVAL) and caches per-path values
+    in ``recordings``. On network or per-endpoint failures the previous good
+    value is kept — the sensors thus stay flat at their last good number
+    rather than resetting to zero, which would trip HA's ``total_increasing``
+    reset detection for energy sensors.
     """
 
     EXTRA_KEYS = ("additional_heater", "silent_mode", "dhw_charge_duration")
@@ -193,14 +209,14 @@ class _K40ExtraEndpointsMixin:
         """Initialize coordinator with the extra-endpoint cache."""
         super().__init__(*args, **kwargs)
         self.extra_data: dict[str, dict | None] = {}
-        self.energy_recordings: dict[str, float] = {}
-        self._last_energy_recordings_fetch = None
+        self.recordings: dict[str, float] = {}
+        self._last_recordings_fetch = None
 
     async def _async_update_data(self):
         """Update via library, then fetch the standalone endpoints."""
         data = await super()._async_update_data()
         await self._fetch_extra_endpoints()
-        await self._fetch_energy_recordings()
+        await self._fetch_recordings()
         return data
 
     async def _fetch_extra_endpoints(self) -> None:
@@ -231,24 +247,26 @@ class _K40ExtraEndpointsMixin:
                 continue
             self.extra_data[key] = result if result else None
 
-    async def _fetch_energy_recordings(self) -> None:
-        """Fetch /recordings/heatSources/emon/* time-series (hourly, rate-limited).
+    async def _fetch_recordings(self) -> None:
+        """Fetch /recordings/heatSources/* time-series (hourly, rate-limited).
 
-        Runs at most once per ENERGY_RECORDINGS_POLL_INTERVAL. The bulk
-        endpoint accepts up to 30 paths per call — 13 fits comfortably.
+        Runs at most once per RECORDINGS_POLL_INTERVAL. The bulk endpoint
+        accepts up to 30 paths per call — 14 fits comfortably. Each entry
+        of RECORDING_PATHS has its own aggregation mode:
+            ``sum`` -> sum of ``y`` (kWh counters)
+            ``avg`` -> sum(y) / sum(c) (sensor sample averages)
         """
         now = dt_util.utcnow()
         if (
-            self._last_energy_recordings_fetch is not None
-            and now - self._last_energy_recordings_fetch
-            < ENERGY_RECORDINGS_POLL_INTERVAL
+            self._last_recordings_fetch is not None
+            and now - self._last_recordings_fetch < RECORDINGS_POLL_INTERVAL
         ):
             return
 
         today = dt_util.now().strftime("%Y-%m-%d")
         paths = [
-            f"/recordings/heatSources/emon/{suffix}?interval={today}"
-            for suffix in ENERGY_RECORDING_PATHS
+            f"/recordings/heatSources/{suffix}?interval={today}"
+            for suffix in RECORDING_PATHS
         ]
         try:
             result = await self.bhc.async_request_bulk(self.unique_id, paths)
@@ -260,7 +278,7 @@ class _K40ExtraEndpointsMixin:
             TimeoutError,
         ):
             _LOGGER.debug(
-                "Device %s: energy recordings fetch failed, keeping last values",
+                "Device %s: recordings fetch failed, keeping last values",
                 self.unique_id,
             )
             return
@@ -268,8 +286,8 @@ class _K40ExtraEndpointsMixin:
         if not result:
             return
 
-        for suffix, key in ENERGY_RECORDING_PATHS.items():
-            path = f"/recordings/heatSources/emon/{suffix}?interval={today}"
+        for suffix, meta in RECORDING_PATHS.items():
+            path = f"/recordings/heatSources/{suffix}?interval={today}"
             payload = result.get(path)
             if not isinstance(payload, dict):
                 # Endpoint not supported on this device (404/403) or unexpected shape.
@@ -278,15 +296,24 @@ class _K40ExtraEndpointsMixin:
             recording = payload.get("recording") or []
             if not isinstance(recording, list):
                 continue
-            total = 0.0
+            y_sum = 0.0
+            c_sum = 0
             for item in recording:
-                if isinstance(item, dict):
-                    y = item.get("y")
-                    if isinstance(y, (int, float)):
-                        total += y
-            self.energy_recordings[key] = round(total, 3)
+                if not isinstance(item, dict):
+                    continue
+                y = item.get("y")
+                c = item.get("c")
+                if isinstance(y, (int, float)):
+                    y_sum += y
+                if isinstance(c, (int, float)):
+                    c_sum += int(c)
+            if meta["agg"] == "avg":
+                if c_sum > 0:
+                    self.recordings[meta["key"]] = round(y_sum / c_sum, 2)
+            else:  # "sum"
+                self.recordings[meta["key"]] = round(y_sum, 3)
 
-        self._last_energy_recordings_fetch = now
+        self._last_recordings_fetch = now
 
 
 class BoschComModuleCoordinatorK40(

--- a/custom_components/bosch_homecom/coordinator.py
+++ b/custom_components/bosch_homecom/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from datetime import timedelta
 import logging
 from typing import TypeVar
 
@@ -11,6 +12,7 @@ from homeassistant.const import CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 from homecom_alt import (
     ApiError,
     AuthFailedError,
@@ -144,6 +146,30 @@ class BoschComModuleCoordinatorRac(BoschComModuleCoordinatorBase[BHCDeviceRac]):
         )
 
 
+ENERGY_RECORDINGS_POLL_INTERVAL = timedelta(hours=1)
+
+# Maps (path_suffix under /recordings/heatSources/emon/) -> local key stored
+# in coordinator.energy_recordings. Discovered via refEnum browsability at
+# GET /resource/recordings/heatSources/emon on a K40 (Bosch Compress 5800iAW).
+# Endpoints the device does not support silently drop out of the bulk response
+# (existing _log_endpoint_status handling) and the previous good value is kept.
+ENERGY_RECORDING_PATHS: dict[str, str] = {
+    "total/compressor": "energy_compressor_total",
+    "total/eheater": "energy_eheater_total",
+    "total/ventilation": "energy_ventilation_total",
+    "total/outputProduced": "heat_produced_total",
+    "ventilation/heatRecovered": "heat_recovered_ventilation",
+    "ch/compressor": "energy_compressor_ch",
+    "ch/eheater": "energy_eheater_ch",
+    "ch/outputProduced": "heat_produced_ch",
+    "dhw/compressor": "energy_compressor_dhw",
+    "dhw/eheater": "energy_eheater_dhw",
+    "dhw/outputProduced": "heat_produced_dhw",
+    "cooling/compressor": "energy_compressor_cooling",
+    "cooling/outputProduced": "heat_produced_cooling",
+}
+
+
 class _K40ExtraEndpointsMixin:
     """Fetch/cache K40-family endpoints not in the homecom_alt bulk update.
 
@@ -152,6 +178,13 @@ class _K40ExtraEndpointsMixin:
     so they are fetched separately and cached in ``extra_data``. Shared by the
     K40 and ICOM coordinators. Endpoints the device does not support resolve to
     ``None`` and simply produce no entity.
+
+    Also fetches the ``/recordings/heatSources/emon/*`` energy time-series at a
+    slower cadence (see ENERGY_RECORDINGS_POLL_INTERVAL) and caches per-path
+    cumulative-today values in ``energy_recordings``. On network or per-endpoint
+    failures the previous good value is kept — the sensors thus stay flat at
+    their last good number rather than resetting to zero, which would trip HA's
+    ``total_increasing`` reset detection.
     """
 
     EXTRA_KEYS = ("additional_heater", "silent_mode", "dhw_charge_duration")
@@ -160,11 +193,14 @@ class _K40ExtraEndpointsMixin:
         """Initialize coordinator with the extra-endpoint cache."""
         super().__init__(*args, **kwargs)
         self.extra_data: dict[str, dict | None] = {}
+        self.energy_recordings: dict[str, float] = {}
+        self._last_energy_recordings_fetch = None
 
     async def _async_update_data(self):
         """Update via library, then fetch the standalone endpoints."""
         data = await super()._async_update_data()
         await self._fetch_extra_endpoints()
+        await self._fetch_energy_recordings()
         return data
 
     async def _fetch_extra_endpoints(self) -> None:
@@ -194,6 +230,63 @@ class _K40ExtraEndpointsMixin:
                 self.extra_data[key] = None
                 continue
             self.extra_data[key] = result if result else None
+
+    async def _fetch_energy_recordings(self) -> None:
+        """Fetch /recordings/heatSources/emon/* time-series (hourly, rate-limited).
+
+        Runs at most once per ENERGY_RECORDINGS_POLL_INTERVAL. The bulk
+        endpoint accepts up to 30 paths per call — 13 fits comfortably.
+        """
+        now = dt_util.utcnow()
+        if (
+            self._last_energy_recordings_fetch is not None
+            and now - self._last_energy_recordings_fetch
+            < ENERGY_RECORDINGS_POLL_INTERVAL
+        ):
+            return
+
+        today = dt_util.now().strftime("%Y-%m-%d")
+        paths = [
+            f"/recordings/heatSources/emon/{suffix}?interval={today}"
+            for suffix in ENERGY_RECORDING_PATHS
+        ]
+        try:
+            result = await self.bhc.async_request_bulk(self.unique_id, paths)
+        except (
+            ApiError,
+            InvalidSensorDataError,
+            NotRespondingError,
+            RetryError,
+            TimeoutError,
+        ):
+            _LOGGER.debug(
+                "Device %s: energy recordings fetch failed, keeping last values",
+                self.unique_id,
+            )
+            return
+
+        if not result:
+            return
+
+        for suffix, key in ENERGY_RECORDING_PATHS.items():
+            path = f"/recordings/heatSources/emon/{suffix}?interval={today}"
+            payload = result.get(path)
+            if not isinstance(payload, dict):
+                # Endpoint not supported on this device (404/403) or unexpected shape.
+                # Keep previous good value if any.
+                continue
+            recording = payload.get("recording") or []
+            if not isinstance(recording, list):
+                continue
+            total = 0.0
+            for item in recording:
+                if isinstance(item, dict):
+                    y = item.get("y")
+                    if isinstance(y, (int, float)):
+                        total += y
+            self.energy_recordings[key] = round(total, 3)
+
+        self._last_energy_recordings_fetch = now
 
 
 class BoschComModuleCoordinatorK40(

--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -448,6 +448,40 @@ async def async_setup_entry(
             if hs.get("starts"):
                 entities.append(BoschComK40StartCountsSensor(coordinator))
 
+            # Energy recordings sensors — the 5 top-level totals + heatRecovered
+            # are enabled by default (main use case: Energy Dashboard),
+            # the 8 per-mode breakdowns are disabled by default (diagnostics).
+            energy_defaults_on = {
+                "energy_compressor_total",
+                "energy_eheater_total",
+                "energy_ventilation_total",
+                "heat_produced_total",
+                "heat_recovered_ventilation",
+            }
+            for key in (
+                "energy_compressor_total",
+                "energy_eheater_total",
+                "energy_ventilation_total",
+                "heat_produced_total",
+                "heat_recovered_ventilation",
+                "energy_compressor_ch",
+                "energy_eheater_ch",
+                "heat_produced_ch",
+                "energy_compressor_dhw",
+                "energy_eheater_dhw",
+                "heat_produced_dhw",
+                "energy_compressor_cooling",
+                "heat_produced_cooling",
+            ):
+                entities.append(
+                    BoschComK40EnergyRecordingSensor(
+                        coordinator,
+                        key,
+                        key,
+                        enabled_default=key in energy_defaults_on,
+                    )
+                )
+
     if entities:
         async_add_entities(entities)
 
@@ -3290,4 +3324,49 @@ class BoschComK40StartCountsSensor(CoordinatorEntity, SensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data."""
+        self.async_write_ha_state()
+
+
+class BoschComK40EnergyRecordingSensor(CoordinatorEntity, SensorEntity):
+    """Cumulative-today energy sensor from /recordings/heatSources/emon/*.
+
+    State is the sum of hourly buckets returned by the recording endpoint for
+    today. Bosch adds a new hourly bucket every ~1h with a 1-2h lag; the value
+    is monotonically increasing within the day and resets to 0 at midnight,
+    matching HA's ``total_increasing`` reset semantic. On fetch failure the
+    previous value is kept (see coordinator._fetch_energy_recordings), so no
+    spurious reset is reported to HA statistics.
+    """
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = "kWh"
+
+    def __init__(
+        self,
+        coordinator: BoschComModuleCoordinatorK40,
+        key: str,
+        translation_key: str,
+        enabled_default: bool,
+    ) -> None:
+        """Initialize energy recording sensor."""
+        super().__init__(coordinator)
+        self._key = key
+        self._attr_translation_key = translation_key
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = f"{coordinator.unique_id}-{key}"
+        self._attr_suggested_object_id = key
+        self._attr_entity_registry_enabled_default = enabled_default
+
+    @property
+    def native_value(self) -> float | None:
+        """Return current cumulative-today kWh."""
+        return self.coordinator.energy_recordings.get(self._key)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data."""
+        self._attr_native_value = self.coordinator.energy_recordings.get(self._key)
         self.async_write_ha_state()

--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -448,15 +448,32 @@ async def async_setup_entry(
             if hs.get("starts"):
                 entities.append(BoschComK40StartCountsSensor(coordinator))
 
-            # Energy recordings sensors — the 5 top-level totals + heatRecovered
-            # are enabled by default (main use case: Energy Dashboard),
-            # the 8 per-mode breakdowns are disabled by default (diagnostics).
-            energy_defaults_on = {
+            # Recording sensors from /recordings/heatSources/*.
+            # Enabled-by-default policy:
+            #   - Top-level totals (5) + supply temperature avg (1) = main use.
+            #   - Per-mode breakdowns (8) = diagnostics, users enable per entity.
+            defaults_on = {
                 "energy_compressor_total",
                 "energy_eheater_total",
                 "energy_ventilation_total",
                 "heat_produced_total",
                 "heat_recovered_ventilation",
+                "supply_temp_avg_today",
+            }
+            energy_keys = {
+                "energy_compressor_total",
+                "energy_eheater_total",
+                "energy_ventilation_total",
+                "heat_produced_total",
+                "heat_recovered_ventilation",
+                "energy_compressor_ch",
+                "energy_eheater_ch",
+                "heat_produced_ch",
+                "energy_compressor_dhw",
+                "energy_eheater_dhw",
+                "heat_produced_dhw",
+                "energy_compressor_cooling",
+                "heat_produced_cooling",
             }
             for key in (
                 "energy_compressor_total",
@@ -472,13 +489,25 @@ async def async_setup_entry(
                 "heat_produced_dhw",
                 "energy_compressor_cooling",
                 "heat_produced_cooling",
+                "supply_temp_avg_today",
             ):
+                if key in energy_keys:
+                    dev_class = SensorDeviceClass.ENERGY
+                    state_class = SensorStateClass.TOTAL_INCREASING
+                    unit = "kWh"
+                else:  # supply_temp_avg_today
+                    dev_class = SensorDeviceClass.TEMPERATURE
+                    state_class = SensorStateClass.MEASUREMENT
+                    unit = "°C"
                 entities.append(
-                    BoschComK40EnergyRecordingSensor(
+                    BoschComK40RecordingSensor(
                         coordinator,
                         key,
                         key,
-                        enabled_default=key in energy_defaults_on,
+                        device_class=dev_class,
+                        state_class=state_class,
+                        native_unit=unit,
+                        enabled_default=key in defaults_on,
                     )
                 )
 
@@ -3327,46 +3356,54 @@ class BoschComK40StartCountsSensor(CoordinatorEntity, SensorEntity):
         self.async_write_ha_state()
 
 
-class BoschComK40EnergyRecordingSensor(CoordinatorEntity, SensorEntity):
-    """Cumulative-today energy sensor from /recordings/heatSources/emon/*.
+class BoschComK40RecordingSensor(CoordinatorEntity, SensorEntity):
+    """Today's-so-far value derived from a /recordings/heatSources/* time-series.
 
-    State is the sum of hourly buckets returned by the recording endpoint for
-    today. Bosch adds a new hourly bucket every ~1h with a 1-2h lag; the value
-    is monotonically increasing within the day and resets to 0 at midnight,
-    matching HA's ``total_increasing`` reset semantic. On fetch failure the
-    previous value is kept (see coordinator._fetch_energy_recordings), so no
-    spurious reset is reported to HA statistics.
+    For energy endpoints (``sum`` aggregation in RECORDING_PATHS), the state is
+    the cumulative kWh for today so far. Bosch adds a new hourly bucket every
+    ~1h with a 1-2h lag; the value is monotonically increasing within the day
+    and resets to 0 at midnight, matching HA's ``total_increasing`` reset
+    semantic. On fetch failure the previous value is kept
+    (see coordinator._fetch_recordings), so no spurious reset is reported to
+    HA statistics.
+
+    For sensor endpoints (``avg`` aggregation), the state is today's running
+    average across all hourly buckets so far — with ``state_class: measurement``
+    (not total_increasing) since it is not cumulative.
     """
 
     _attr_has_entity_name = True
     _attr_should_poll = False
-    _attr_device_class = SensorDeviceClass.ENERGY
-    _attr_state_class = SensorStateClass.TOTAL_INCREASING
-    _attr_native_unit_of_measurement = "kWh"
 
     def __init__(
         self,
         coordinator: BoschComModuleCoordinatorK40,
         key: str,
         translation_key: str,
+        device_class: SensorDeviceClass,
+        state_class: SensorStateClass,
+        native_unit: str,
         enabled_default: bool,
     ) -> None:
-        """Initialize energy recording sensor."""
+        """Initialize recording sensor."""
         super().__init__(coordinator)
         self._key = key
         self._attr_translation_key = translation_key
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{coordinator.unique_id}-{key}"
         self._attr_suggested_object_id = key
+        self._attr_device_class = device_class
+        self._attr_state_class = state_class
+        self._attr_native_unit_of_measurement = native_unit
         self._attr_entity_registry_enabled_default = enabled_default
 
     @property
     def native_value(self) -> float | None:
-        """Return current cumulative-today kWh."""
-        return self.coordinator.energy_recordings.get(self._key)
+        """Return today's-so-far value from the coordinator cache."""
+        return self.coordinator.recordings.get(self._key)
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data."""
-        self._attr_native_value = self.coordinator.energy_recordings.get(self._key)
+        self._attr_native_value = self.coordinator.recordings.get(self._key)
         self.async_write_ha_state()

--- a/custom_components/bosch_homecom/translations/de.json
+++ b/custom_components/bosch_homecom/translations/de.json
@@ -426,6 +426,9 @@
       },
       "heat_produced_cooling": {
         "name": "Wärme erzeugt Kühlung"
+      },
+      "supply_temp_avg_today": {
+        "name": "Vorlauftemperatur (Tages-Ø)"
       }
     },
     "binary_sensor": {

--- a/custom_components/bosch_homecom/translations/de.json
+++ b/custom_components/bosch_homecom/translations/de.json
@@ -387,6 +387,45 @@
       },
       "water_total_consumption": {
         "name": "Wasserverbrauch"
+      },
+      "energy_compressor_total": {
+        "name": "Strom Kompressor gesamt"
+      },
+      "energy_eheater_total": {
+        "name": "Strom Heizstab gesamt"
+      },
+      "energy_ventilation_total": {
+        "name": "Strom Lüftung gesamt"
+      },
+      "heat_produced_total": {
+        "name": "Wärme erzeugt gesamt"
+      },
+      "heat_recovered_ventilation": {
+        "name": "Wärmerückgewinnung Lüftung"
+      },
+      "energy_compressor_ch": {
+        "name": "Strom Kompressor Heizung"
+      },
+      "energy_eheater_ch": {
+        "name": "Strom Heizstab Heizung"
+      },
+      "heat_produced_ch": {
+        "name": "Wärme erzeugt Heizung"
+      },
+      "energy_compressor_dhw": {
+        "name": "Strom Kompressor Warmwasser"
+      },
+      "energy_eheater_dhw": {
+        "name": "Strom Heizstab Warmwasser"
+      },
+      "heat_produced_dhw": {
+        "name": "Wärme erzeugt Warmwasser"
+      },
+      "energy_compressor_cooling": {
+        "name": "Strom Kompressor Kühlung"
+      },
+      "heat_produced_cooling": {
+        "name": "Wärme erzeugt Kühlung"
       }
     },
     "binary_sensor": {

--- a/custom_components/bosch_homecom/translations/en.json
+++ b/custom_components/bosch_homecom/translations/en.json
@@ -424,6 +424,9 @@
       },
       "heat_produced_cooling": {
         "name": "Heat produced cooling"
+      },
+      "supply_temp_avg_today": {
+        "name": "Supply temperature (today average)"
       }
     },
     "binary_sensor": {

--- a/custom_components/bosch_homecom/translations/en.json
+++ b/custom_components/bosch_homecom/translations/en.json
@@ -385,6 +385,45 @@
       },
       "water_total_consumption": {
         "name": "Water Consumption"
+      },
+      "energy_compressor_total": {
+        "name": "Compressor electricity total"
+      },
+      "energy_eheater_total": {
+        "name": "Electric heater electricity total"
+      },
+      "energy_ventilation_total": {
+        "name": "Ventilation electricity total"
+      },
+      "heat_produced_total": {
+        "name": "Heat produced total"
+      },
+      "heat_recovered_ventilation": {
+        "name": "Ventilation heat recovered"
+      },
+      "energy_compressor_ch": {
+        "name": "Compressor electricity heating"
+      },
+      "energy_eheater_ch": {
+        "name": "Electric heater electricity heating"
+      },
+      "heat_produced_ch": {
+        "name": "Heat produced heating"
+      },
+      "energy_compressor_dhw": {
+        "name": "Compressor electricity DHW"
+      },
+      "energy_eheater_dhw": {
+        "name": "Electric heater electricity DHW"
+      },
+      "heat_produced_dhw": {
+        "name": "Heat produced DHW"
+      },
+      "energy_compressor_cooling": {
+        "name": "Compressor electricity cooling"
+      },
+      "heat_produced_cooling": {
+        "name": "Heat produced cooling"
       }
     },
     "binary_sensor": {

--- a/tests/test_extra_entities.py
+++ b/tests/test_extra_entities.py
@@ -218,6 +218,7 @@ async def test_k40_coordinator_fetches_extra_endpoints(hass, entry, device, firm
     bhc.async_get_additional_heater_mode = AsyncMock(return_value={"value": "auto"})
     bhc.async_get_silent_mode = AsyncMock(return_value={"value": "off"})
     bhc.async_get_dhw_charge_duration = AsyncMock(return_value={"value": 60.0})
+    bhc.async_request_bulk = AsyncMock(return_value={})
 
     coordinator = BoschComModuleCoordinatorK40(
         hass, bhc, device, firmware, entry, auth_provider=False
@@ -245,6 +246,7 @@ async def test_k40_coordinator_extra_endpoint_failure_graceful(
     bhc.async_get_additional_heater_mode = AsyncMock(side_effect=ApiError("boom"))
     bhc.async_get_silent_mode = AsyncMock(side_effect=ApiError("boom"))
     bhc.async_get_dhw_charge_duration = AsyncMock(side_effect=ApiError("boom"))
+    bhc.async_request_bulk = AsyncMock(side_effect=ApiError("boom"))
 
     coordinator = BoschComModuleCoordinatorK40(
         hass, bhc, device, firmware, entry, auth_provider=False
@@ -277,6 +279,126 @@ async def test_icom_coordinator_shares_extra_endpoints(hass, entry, firmware):
 
     for key in BoschComModuleCoordinatorIcom.EXTRA_KEYS:
         assert coordinator.extra_data.get(key) is not None
+
+
+# ===================================================================
+# Energy recordings tests (_fetch_recordings)
+# ===================================================================
+
+
+def _make_recording_payload(hourly_kwh: list[float]) -> dict:
+    """Build a Bosch yRecording payload with the given hourly buckets."""
+    return {
+        "type": "yRecording",
+        "unitOfMeasure": "kWh",
+        "recording": [{"y": v, "c": 1} for v in hourly_kwh],
+    }
+
+
+@pytest.mark.asyncio
+async def test_k40_coordinator_fetches_recordings(
+    hass, entry, device, firmware
+):
+    """K40 coordinator sums hourly buckets from /recordings/emon/* endpoints."""
+    entry.add_to_hass(hass)
+
+    # Distinguishable payloads: sum for kWh, avg (y/c) for supply temperature
+    def _bulk_response(dev_id, paths):
+        assert dev_id == "102128202"
+        assert len(paths) == 14  # 13 emon + 1 actualSupplyTemperature
+        result = {}
+        for p in paths:
+            if "emon/total/ventilation" in p:
+                result[p] = _make_recording_payload([0.04, 0.04, 0.04, 0.05])  # 0.17
+            elif "emon/total/compressor" in p:
+                result[p] = _make_recording_payload([1.5, 2.0, 0.5])  # 4.0
+            elif "actualSupplyTemperature" in p:
+                # Avg aggregation: y/c per bucket, then overall sum(y)/sum(c)
+                # 2700/100 = 27.0, 4500/150 = 30.0. Overall 7200/250 = 28.80
+                result[p] = {
+                    "type": "yRecording",
+                    "unitOfMeasure": "C",
+                    "recording": [
+                        {"y": 2700.0, "c": 100},
+                        {"y": 4500.0, "c": 150},
+                    ],
+                }
+        return result
+
+    bhc = MagicMock()
+    bhc.get_token = AsyncMock()
+    bhc.async_update = AsyncMock(return_value=_make_k40_data())
+    bhc.async_get_additional_heater_mode = AsyncMock(return_value={"value": "auto"})
+    bhc.async_get_silent_mode = AsyncMock(return_value={"value": "off"})
+    bhc.async_get_dhw_charge_duration = AsyncMock(return_value={"value": 60.0})
+    bhc.async_request_bulk = AsyncMock(side_effect=_bulk_response)
+
+    coordinator = BoschComModuleCoordinatorK40(
+        hass, bhc, device, firmware, entry, auth_provider=False
+    )
+    await coordinator._async_update_data()
+
+    # Successful fetches produced expected values
+    assert coordinator.recordings["energy_ventilation_total"] == 0.17
+    assert coordinator.recordings["energy_compressor_total"] == 4.0
+    # Avg-aggregation: sum(y)=7200 / sum(c)=250 = 28.80
+    assert coordinator.recordings["supply_temp_avg_today"] == 28.80
+    # Endpoints not in the response keep no value at all (dict absence)
+    assert "heat_produced_total" not in coordinator.recordings
+
+
+@pytest.mark.asyncio
+async def test_k40_coordinator_recordings_rate_limited(
+    hass, entry, device, firmware
+):
+    """Second update within the interval must not re-fetch energy recordings."""
+    entry.add_to_hass(hass)
+    bhc = MagicMock()
+    bhc.get_token = AsyncMock()
+    bhc.async_update = AsyncMock(return_value=_make_k40_data())
+    bhc.async_get_additional_heater_mode = AsyncMock(return_value={"value": "auto"})
+    bhc.async_get_silent_mode = AsyncMock(return_value={"value": "off"})
+    bhc.async_get_dhw_charge_duration = AsyncMock(return_value={"value": 60.0})
+    bhc.async_request_bulk = AsyncMock(return_value={})
+
+    coordinator = BoschComModuleCoordinatorK40(
+        hass, bhc, device, firmware, entry, auth_provider=False
+    )
+    await coordinator._async_update_data()
+    await coordinator._async_update_data()
+    await coordinator._async_update_data()
+
+    # First call fetches; subsequent calls within the 1h interval don't.
+    assert bhc.async_request_bulk.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_k40_coordinator_recordings_failure_keeps_last_good(
+    hass, entry, device, firmware
+):
+    """On API failure, previous good values are retained (no reset to zero/None)."""
+    from homecom_alt import ApiError
+
+    entry.add_to_hass(hass)
+    bhc = MagicMock()
+    bhc.get_token = AsyncMock()
+    bhc.async_update = AsyncMock(return_value=_make_k40_data())
+    bhc.async_get_additional_heater_mode = AsyncMock(return_value={"value": "auto"})
+    bhc.async_get_silent_mode = AsyncMock(return_value={"value": "off"})
+    bhc.async_get_dhw_charge_duration = AsyncMock(return_value={"value": 60.0})
+    bhc.async_request_bulk = AsyncMock(side_effect=ApiError("network dead"))
+
+    coordinator = BoschComModuleCoordinatorK40(
+        hass, bhc, device, firmware, entry, auth_provider=False
+    )
+    # Seed a known-good value that should survive the failure
+    coordinator.recordings["energy_compressor_total"] = 42.0
+
+    data = await coordinator._async_update_data()
+
+    assert data is not None
+    # Value preserved through the failed fetch — no reset
+    assert coordinator.recordings["energy_compressor_total"] == 42.0
 
 
 # ===================================================================

--- a/tests/test_extra_entities.py
+++ b/tests/test_extra_entities.py
@@ -296,9 +296,7 @@ def _make_recording_payload(hourly_kwh: list[float]) -> dict:
 
 
 @pytest.mark.asyncio
-async def test_k40_coordinator_fetches_recordings(
-    hass, entry, device, firmware
-):
+async def test_k40_coordinator_fetches_recordings(hass, entry, device, firmware):
     """K40 coordinator sums hourly buckets from /recordings/emon/* endpoints."""
     entry.add_to_hass(hass)
 
@@ -348,9 +346,7 @@ async def test_k40_coordinator_fetches_recordings(
 
 
 @pytest.mark.asyncio
-async def test_k40_coordinator_recordings_rate_limited(
-    hass, entry, device, firmware
-):
+async def test_k40_coordinator_recordings_rate_limited(hass, entry, device, firmware):
     """Second update within the interval must not re-fetch energy recordings."""
     entry.add_to_hass(hass)
     bhc = MagicMock()

--- a/tests/test_extra_entities.py
+++ b/tests/test_extra_entities.py
@@ -397,6 +397,65 @@ async def test_k40_coordinator_recordings_failure_keeps_last_good(
     assert coordinator.recordings["energy_compressor_total"] == 42.0
 
 
+@pytest.mark.asyncio
+async def test_k40_coordinator_recordings_skips_future_slots(
+    hass, entry, device, firmware
+):
+    """Placeholders with c<=0 (future / unpopulated hours) must not be counted.
+
+    Regression for the bug reported by @ombuyse in PR #155: the Buderus
+    Logatherm WLW166i returns ``{"c": 0, "y": 1.0}`` for every hour of the
+    current day that is not yet populated. Both ``sum`` and ``avg``
+    aggregations must skip those entries.
+    """
+    entry.add_to_hass(hass)
+
+    def _bulk_response(dev_id, paths):
+        result = {}
+        for p in paths:
+            if "emon/total/compressor" in p:
+                # 3 real hours totalling 9 kWh, followed by 11 c=0 y=1 slots.
+                # Bug: 9 + 11 = 20. Fixed: 9.
+                real = [{"y": 3.0, "c": 1}, {"y": 2.0, "c": 1}, {"y": 4.0, "c": 1}]
+                future = [{"y": 1.0, "c": 0}] * 11
+                result[p] = {
+                    "type": "yRecording",
+                    "unitOfMeasure": "kWh",
+                    "recording": real + future,
+                }
+            elif "actualSupplyTemperature" in p:
+                # 2 real buckets averaging to 28.0, one c=0 y=999 placeholder.
+                # Bug: (2700+4500+999)/(100+150) = 32.796. Fixed: 7200/250 = 28.80.
+                result[p] = {
+                    "type": "yRecording",
+                    "unitOfMeasure": "C",
+                    "recording": [
+                        {"y": 2700.0, "c": 100},
+                        {"y": 4500.0, "c": 150},
+                        {"y": 999.0, "c": 0},
+                    ],
+                }
+        return result
+
+    bhc = MagicMock()
+    bhc.get_token = AsyncMock()
+    bhc.async_update = AsyncMock(return_value=_make_k40_data())
+    bhc.async_get_additional_heater_mode = AsyncMock(return_value={"value": "auto"})
+    bhc.async_get_silent_mode = AsyncMock(return_value={"value": "off"})
+    bhc.async_get_dhw_charge_duration = AsyncMock(return_value={"value": 60.0})
+    bhc.async_request_bulk = AsyncMock(side_effect=_bulk_response)
+
+    coordinator = BoschComModuleCoordinatorK40(
+        hass, bhc, device, firmware, entry, auth_provider=False
+    )
+    await coordinator._async_update_data()
+
+    # Sum aggregation: only the 3 real hours count.
+    assert coordinator.recordings["energy_compressor_total"] == 9.0
+    # Avg aggregation: only the 2 real buckets count, placeholder ignored.
+    assert coordinator.recordings["supply_temp_avg_today"] == 28.80
+
+
 # ===================================================================
 # Sensor entity tests
 # ===================================================================


### PR DESCRIPTION
Follows up on #152 (which added `get_recordings_service`) and closes #153. Adds native cumulative-today energy sensors for the K40/ICOM device family on top of the recordings infrastructure.

## Background

The Bosch app's Energy Monitoring view is fed by `/recordings/heatSources/emon/*` — accessible only via POST /bulk. #152 exposed that transport layer. This PR wires 13 concrete sensors on top of it for K40 devices.

Full endpoint tree (discovered via refEnum lookup at `GET /resource/recordings/heatSources/emon` on a Bosch Compress 5800iAW, see #153):

```
/recordings/heatSources/emon/
├── total/            → cross-mode aggregate
│   ├── compressor    (kWh) ← electricity consumed by compressor
│   ├── eheater       (kWh) ← electricity consumed by resistive heater
│   ├── ventilation   (kWh) ← electricity consumed by ventilation fan
│   └── outputProduced (kWh) ← heat delivered to hydraulics
├── ch/               → central-heating mode only (subset of total)
│   ├── compressor
│   ├── eheater
│   └── outputProduced
├── dhw/              → DHW mode only
│   ├── compressor
│   ├── eheater
│   └── outputProduced
├── cooling/          → cooling mode only (no eheater — physically N/A)
│   ├── compressor
│   └── outputProduced
└── ventilation/
    └── heatRecovered → heat recovered by the enthalpy exchanger
```

## Behaviour

- **Slow polling.** Fetch rate is limited to 1x/hour in `_K40ExtraEndpointsMixin._fetch_energy_recordings`. Bosch's own aggregation tier lags by ~1-2h so polling faster is waste, and it protects the pointt-api from unnecessary bulk requests.
- **Cumulative-today state.** Each sensor's value is the sum of hourly buckets returned for today (`?interval=YYYY-MM-DD`). `state_class: total_increasing` handles HA's midnight-reset semantic automatically.
- **Failure-safe.** On per-endpoint or network failure the previous good value is kept — never overwritten with 0 or unavailable — so HA statistics doesn't spuriously detect a reset. Endpoints unsupported by a given device just silently drop out of the bulk response (existing `_log_endpoint_status` behaviour).
- **Device-class energy, unit kWh.** All 13 sensors are picked up by the Energy Dashboard as consumption/production sources.

## Enabled-by-default policy

The five top-level aggregates ("Wärmepumpe verbrauchte Energie" and "Lüftung Wärmerückgewinnung" in the app) are enabled by default — these are the main Energy Dashboard use case. The eight per-mode breakdowns are disabled by default (diagnostics for power users; users click "enable" per entity in the device page).

## Verified

Tested on real K40 hardware (Bosch Compress 5800iAW / HomeCom Easy):

| Sensor | Value on my install |
|---|---|
| Strom Kompressor gesamt | 6.61 kWh (running total today) |
| Strom Heizstab gesamt   | 3.00 kWh |
| Strom Lüftung gesamt    | 3.86 kWh |
| Wärme erzeugt gesamt    | 12.21 kWh |
| Wärmerückgewinnung Lüftung | 5.11 kWh |

All sensors populate on first hourly poll after config-entry load and reset cleanly at midnight (verified against the recordings JSON shape).

## Diff

```
custom_components/bosch_homecom/coordinator.py    | 93 +++++++++++++
custom_components/bosch_homecom/sensor.py         | 79 ++++++++++++
custom_components/bosch_homecom/translations/de.json | 41 +++++-
custom_components/bosch_homecom/translations/en.json | 41 +++++-
4 files changed, 252 insertions(+), 2 deletions(-)
```

## Non-goals

- No LTS backfill of historical data (would need `async_add_external_statistics`; can be a separate PR if there's demand). Users can still hit /recordings/* via the `get_recordings_service` (from #152) for one-off historical fetches.
- No config options (poll interval is hard-coded to 1h — matches Bosch's aggregation cadence).
- No RRC2/RAC support — only K40/ICOM. RRC2 devices have a different endpoint surface and would need their own discovery.