### PR TITLE
fix: send DHW chargeDuration as number, not string (HTTP 400)

### DIFF
--- a/custom_components/bosch_homecom/number.py
+++ b/custom_components/bosch_homecom/number.py
@@ -657,7 +657,7 @@ class BoschComK40DhwChargeDurationNumber(CoordinatorEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Set the charge duration."""
         await self.coordinator.bhc.async_set_dhw_charge_duration(
-            self.coordinator.data.device["deviceId"], "dhw1", str(int(value))
+            self.coordinator.data.device["deviceId"], "dhw1", int(value)
         )
         await self.coordinator.async_request_refresh()
 

--- a/tests/test_extra_entities.py
+++ b/tests/test_extra_entities.py
@@ -416,7 +416,7 @@ async def test_dhw_charge_duration_set_value():
     await number.async_set_native_value(120.0)
 
     coordinator.bhc.async_set_dhw_charge_duration.assert_awaited_once_with(
-        "102128202", "dhw1", "120"
+        "102128202", "dhw1", 120
     )
     coordinator.async_request_refresh.assert_awaited_once()
 


### PR DESCRIPTION
## Problem

Setting the DHW charge duration (the `*_dhw_charge_duration` number entity, "Warmwasser Ladedauer") fails with:

```
Invalid response from url .../pointt-api/api/v1/gateways/<id>/resource/dhwCircuits/dhw1/chargeDuration: 400
```

This also breaks any script/service flow that sets the charge duration before starting an extra-hot-water charge.

## Root cause

`BoschComK40DhwChargeDurationNumber.async_set_native_value` passes `str(int(value))` to `async_set_dhw_charge_duration`, so the integration sends `{"value": "60"}` — a **string** — to the `chargeDuration` resource. That resource is a `floatValue` field, and Bosch rejects the string payload with HTTP 400.

## Fix

Send `int(value)` so the payload is a JSON number (`{"value": 60}`), which the API accepts.

```diff
-            self.coordinator.data.device["deviceId"], "dhw1", str(int(value))
+            self.coordinator.data.device["deviceId"], "dhw1", int(value)
```

## Testing

- Updated `tests/test_extra_entities.py::test_dhw_charge_duration_set_value` to assert the numeric payload.
- `ruff` clean; `mypy` clean on `number.py`.
- Verified live on a Bosch Compress CS5800iAW 12 (K40, monoblock AW 7 OR-S): setting the charge-duration number now succeeds with no 400.
