### PR TITLE
feat: support Matter/Bacon-commissioned RAC ACs over MQTT device-shadow

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,68 @@
+# Add support for Matter/"Bacon"-commissioned RAC air conditioners (cloud MQTT device-shadow)
+
+## Problem
+
+Bosch Climate AC units that are commissioned through the HomeCom Easy app **over Matter**
+(serial numbers like `86DM-580-…`) never show up in this integration. Device discovery
+reads only the pointt `/gateways/` endpoint, which returns an empty list for these units —
+they are not pointt gateways. Setup therefore completes with **0 devices** and the user is
+told (issue #115) to "use Matter instead". This affects the Climate 3000i/5000i/6000i family
+when added via the app's Matter/BLE pairing flow.
+
+These devices are instead managed by Bosch's **"bacon"** backend and controlled over an
+AWS-IoT-style **device shadow via MQTT 5 (WebSocket)** — the same channel the official app uses.
+
+## What this PR does
+
+Adds a parallel discovery + control path for these devices, alongside the existing pointt
+REST path (fully additive; the pointt flow is unchanged and degrades gracefully if the bacon
+discovery call fails).
+
+- **Discovery**: `GET https://claiming.euc1.bacon.bosch-tt-cw.com/v1/users/self/devices`
+  returns the user's Matter device serials. They are surfaced in the config-flow device
+  picker as `deviceType: "bacon_rac"`.
+- **Transport**: one shared MQTT 5 / WebSocket connection per config entry to
+  `wss://broker.euc1.bacon.bosch-tt-cw.com:443/mqtt`.
+- **State**: read via the shadow `get` topic; live changes pushed via `update/accepted`.
+- **Control**: publish `{"state":{"desired":{…}}}` to the shadow `update` topic.
+- **Entity**: a `climate` entity per unit (power, hvac mode, target temperature, fan speed, swing).
+
+## Reverse-engineered protocol (verified live)
+
+- ClientID **must** be a 64-char lowercase hex string (otherwise CONNACK `Not authorized`).
+- WebSocket upgrade headers: `Authorization: Bearer <accessToken>` and
+  `User-Agent: DashApp/<ver> (Android-Release)`.
+- MQTT CONNECT: username = the JWT `sub` claim, password = the raw access token
+  (the same SingleKey OIDC token already managed by this integration; scope must include `bacon`).
+- Topics: `users/{sub}/devices/{serial}/shadows/state/{get|update}[/accepted|/rejected]`.
+- RAC shadow fields: `powerEnabled`, `opMode` (`cool|heat|auto|dry|fan`),
+  `fanSpeed` (`auto|quiet|low|medium|high|turbo`), `tempSetpoint` (°C int),
+  `hSwingEnabled`, `vSwingEnabled`, plus `fullPowerEnabled`/`sleepEnabled`/`ionizerEnabled`/…
+  `reported.customTitle` carries the friendly name.
+
+## Files
+
+**`homecom_alt` (library, bumped to 1.7.0):**
+- `bacon.py` (new): `async_get_bacon_devices`, `BaconMqttClient`, `HomeComBaconRac`, `decode_jwt_sub`, `generate_client_id`.
+- `const.py`: bacon broker/claim/topic constants.
+- `model.py`: `BHCDeviceBaconRac`.
+- `pyproject.toml`: `paho-mqtt>=2.0` dependency.
+- `tests/test_bacon.py`.
+
+**`bosch-homecom-hass` (integration, bumped to 1.4.0):**
+- `config_flow.py`: merge bacon devices into discovery.
+- `__init__.py`: shared `BaconMqttClient`, one coordinator per bacon device.
+- `coordinator.py`: `BoschComModuleCoordinatorBaconRac` (MQTT push + periodic keep-alive/reconnect + single-owner token rotation).
+- `climate.py`: `BoschComBaconRacClimate`.
+- `const.py`: `bacon_rac` model label, `CONF_BACON_CLIENT_ID`.
+- `manifest.json`: requirement `homecom_alt>=1.7.0`.
+
+## Notes / limitations
+
+- Only RAC (air conditioners) is implemented so far. The bacon backend also serves DHW and
+  air-purifier shadows with the same transport; those can follow.
+- Token ownership: refresh tokens are single-use, so exactly one coordinator "owns" the
+  refresh (the pointt auth-provider if present, otherwise the first bacon coordinator);
+  the rest reuse the token persisted on the config entry.
+- A stable 64-hex `client_id` is generated once and persisted on the entry so the HA
+  connection never collides with the phone app's client id.

--- a/custom_components/bosch_homecom/__init__.py
+++ b/custom_components/bosch_homecom/__init__.py
@@ -10,8 +10,10 @@ from aiohttp.client_exceptions import ClientConnectorError, ClientError
 from homecom_alt import (
     ApiError,
     AuthFailedError,
+    BaconMqttClient,
     ConnectionOptions,
     HomeComAlt,
+    HomeComBaconRac,
     HomeComCommodule,
     HomeComGeneric,
     HomeComIcom,
@@ -20,6 +22,9 @@ from homecom_alt import (
     HomeComRrc2,
     HomeComWddw2,
     NotRespondingError,
+    async_get_bacon_devices,
+    decode_jwt_sub,
+    generate_client_id,
 )
 
 from homeassistant.config_entries import ConfigEntry
@@ -35,7 +40,11 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from homecom_alt.const import BACON_DEFAULT_REGION
+
 from .const import (
+    CONF_BACON_CLIENT_ID,
+    CONF_BACON_REGION,
     CONF_BRAND_BUDERUS,
     CONF_REFRESH,
     DOMAIN,
@@ -44,6 +53,7 @@ from .const import (
     DEFAULT_UPDATE_INTERVAL,
 )
 from .coordinator import (
+    BoschComModuleCoordinatorBaconRac,
     BoschComModuleCoordinatorCommodule,
     BoschComModuleCoordinatorGeneric,
     BoschComModuleCoordinatorIcom,
@@ -108,6 +118,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if asyncio.iscoroutine(devices):
         devices = await devices
 
+    # Matter/Bacon devices are not in the pointt gateway listing; re-discover
+    # them here so previously-selected ones are set up on reload.
+    bacon_region = entry.data.get(CONF_BACON_REGION) or BACON_DEFAULT_REGION
+    try:
+        devices = list(devices) + await async_get_bacon_devices(
+            websession, bhc.token, bacon_region
+        )
+    except Exception:  # noqa: BLE001 - never block pointt setup
+        _LOGGER.warning("Could not fetch Bacon devices at setup", exc_info=True)
+
     config_devices: dict | None = entry.data.get(CONF_DEVICES)
     filtered_devices = [
         device
@@ -117,6 +137,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     is_first = True
     for device in filtered_devices:
+        if device["deviceType"] == "bacon_rac":
+            # Matter/Bacon devices are set up below over MQTT, not pointt REST.
+            continue
         device_id = device["deviceId"]
         try:
             firmware = await bhc.async_get_firmware(device_id)
@@ -221,6 +244,54 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 )
             )
 
+    # Matter/Bacon-commissioned RAC devices: one shared MQTT device-shadow
+    # connection, one coordinator per device.
+    bacon_devices = [
+        device
+        for device in filtered_devices
+        if device["deviceType"] == "bacon_rac"
+    ]
+    if bacon_devices:
+        client_id = entry.data.get(CONF_BACON_CLIENT_ID)
+        if not client_id:
+            client_id = generate_client_id()
+            new_data = dict(entry.data)
+            new_data[CONF_BACON_CLIENT_ID] = client_id
+            hass.config_entries.async_update_entry(entry, data=new_data)
+
+        bacon_client = BaconMqttClient(client_id, region=bacon_region)
+        sub = decode_jwt_sub(bhc.token)
+        if not sub:
+            raise ConfigEntryAuthFailed("Could not derive user id from token")
+        try:
+            await bacon_client.async_connect(bhc.token, sub)
+        except AuthFailedError as err:
+            raise ConfigEntryAuthFailed from err
+        except (ApiError, ClientError, ClientConnectorError, TimeoutError) as err:
+            raise ConfigEntryNotReady from err
+        entry.async_on_unload(bacon_client.async_disconnect)
+
+        bacon_lock = asyncio.Lock()
+        # A single token owner (refresh tokens are single-use). If there are no
+        # pointt coordinators, the first bacon coordinator owns the refresh.
+        bacon_auth_provider = len(coordinators) == 0
+        for device in bacon_devices:
+            coordinators.append(
+                BoschComModuleCoordinatorBaconRac(
+                    hass,
+                    HomeComBaconRac(bacon_client, device["deviceId"]),
+                    device,
+                    {"value": "unknown"},
+                    entry,
+                    bacon_client,
+                    bhc,
+                    bacon_lock,
+                    bacon_auth_provider,
+                )
+            )
+            bacon_auth_provider = False
+
+
     await asyncio.gather(
         *[
             coordinator.async_config_entry_first_refresh()
@@ -232,10 +303,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Create a new Device for each coorodinator to represent each module
     for c in coordinators:
+        dev_name = c.device["deviceId"]
+        # Bacon devices carry a friendly name (customTitle) in their shadow;
+        # the coordinator stores it on device_info once the first state arrives.
+        if c.device["deviceType"] == "bacon_rac":
+            dev_name = c.device_info.get("name") or dev_name
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
             identifiers={(DOMAIN, c.device["deviceId"])},
-            name=c.device["deviceId"],
+            name=dev_name,
             manufacturer="Bosch",
             model=MODEL.get(c.device["deviceType"], c.device["deviceType"]),
             sw_version=c.firmware,

--- a/custom_components/bosch_homecom/climate.py
+++ b/custom_components/bosch_homecom/climate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+
 from typing import Any, Literal
 
 from homeassistant import config_entries
@@ -28,6 +29,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .coordinator import (
+    BoschComModuleCoordinatorBaconRac,
     BoschComModuleCoordinatorIcom,
     BoschComModuleCoordinatorK40,
     BoschComModuleCoordinatorRac,
@@ -58,6 +60,8 @@ async def async_setup_entry(
 
         if device_type == "rac":
             entities.append(BoschComRacClimate(coordinator=coordinator, field="clima"))
+        elif device_type == "bacon_rac":
+            entities.append(BoschComBaconRacClimate(coordinator=coordinator))
         elif device_type in ("k40", "k30", "icom"):
             for ref in coordinator.data.heating_circuits:
                 hc_id = ref["id"].split("/")[-1]
@@ -749,3 +753,136 @@ class BoschComRrc2ZoneClimate(CoordinatorEntity, ClimateEntity):
         if user_mode == "manual":
             return entry.get("manualTemperatureHeating") or {}
         return entry.get("temperatureHeatingSetpoint") or {}
+
+
+# --- Bacon (Matter-commissioned) RAC over MQTT device-shadow -----------------
+
+BACON_OP_MODE_TO_HVAC: dict[str, HVACMode] = {
+    "cool": HVACMode.COOL,
+    "heat": HVACMode.HEAT,
+    "auto": HVACMode.AUTO,
+    "dry": HVACMode.DRY,
+    "fan": HVACMode.FAN_ONLY,
+}
+BACON_HVAC_TO_OP_MODE: dict[HVACMode, str] = {
+    v: k for k, v in BACON_OP_MODE_TO_HVAC.items()
+}
+BACON_FAN_MODES: list[str] = ["auto", "quiet", "low", "medium", "high", "turbo"]
+
+
+def _clean_bacon_title(title: str | None) -> str | None:
+    """Strip the ``%|$?*...`` suffix Bosch appends to the shadow customTitle."""
+    if not title:
+        return None
+    return title.split("%|")[0].strip() or None
+
+
+class BoschComBaconRacClimate(
+    CoordinatorEntity[BoschComModuleCoordinatorBaconRac], ClimateEntity
+):
+    """Climate entity for a Matter/Bacon-commissioned RAC controlled over MQTT."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_target_temperature_step = 1.0
+    _attr_min_temp = 16
+    _attr_max_temp = 30
+    _attr_fan_modes = BACON_FAN_MODES
+    _attr_swing_modes = [SWING_OFF, SWING_ON]
+    _attr_hvac_modes = [
+        HVACMode.OFF,
+        HVACMode.COOL,
+        HVACMode.HEAT,
+        HVACMode.AUTO,
+        HVACMode.DRY,
+        HVACMode.FAN_ONLY,
+    ]
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.FAN_MODE
+        | ClimateEntityFeature.SWING_MODE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+    )
+
+    def __init__(self, coordinator: BoschComModuleCoordinatorBaconRac) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.unique_id}-climate"
+        title = _clean_bacon_title(self._reported.get("customTitle"))
+        if title:
+            coordinator.device_info["name"] = title
+        self._attr_device_info = coordinator.device_info
+
+    @property
+    def _reported(self) -> dict:
+        data = self.coordinator.data
+        return (data.reported if data else {}) or {}
+
+    @property
+    def hvac_mode(self) -> HVACMode:
+        """Return current operation."""
+        reported = self._reported
+        if not reported.get("powerEnabled"):
+            return HVACMode.OFF
+        return BACON_OP_MODE_TO_HVAC.get(reported.get("opMode"), HVACMode.AUTO)
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the target temperature."""
+        return self._reported.get("tempSetpoint")
+
+    @property
+    def fan_mode(self) -> str | None:
+        """Return the fan setting."""
+        return self._reported.get("fanSpeed")
+
+    @property
+    def swing_mode(self) -> str:
+        """Return the swing setting."""
+        reported = self._reported
+        if reported.get("hSwingEnabled") or reported.get("vSwingEnabled"):
+            return SWING_ON
+        return SWING_OFF
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set new target temperature."""
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        if temperature is None:
+            return
+        await self.coordinator.bhc.async_set_temperature(int(temperature))
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set new operation mode."""
+        if hvac_mode == HVACMode.OFF:
+            await self.coordinator.bhc.async_set_power(False)
+        else:
+            await self.coordinator.bhc.async_set_power(
+                True, BACON_HVAC_TO_OP_MODE.get(hvac_mode)
+            )
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_on(self) -> None:
+        """Turn the entity on."""
+        await self.coordinator.bhc.async_set_power(True)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self) -> None:
+        """Turn the entity off."""
+        await self.coordinator.bhc.async_set_power(False)
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        """Set new fan mode."""
+        await self.coordinator.bhc.async_set_fan(fan_mode)
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_swing_mode(self, swing_mode: str) -> None:
+        """Set new swing mode (drives both horizontal and vertical louvers)."""
+        enabled = swing_mode == SWING_ON
+        await self.coordinator.bhc.async_set_swing(
+            horizontal=enabled, vertical=enabled
+        )
+        await self.coordinator.async_request_refresh()

--- a/custom_components/bosch_homecom/config_flow.py
+++ b/custom_components/bosch_homecom/config_flow.py
@@ -20,10 +20,19 @@ from homeassistant.const import CONF_CODE, CONF_TOKEN, CONF_USERNAME
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-from homecom_alt import ApiError, AuthFailedError, ConnectionOptions, HomeComAlt
+from homecom_alt import (
+    ApiError,
+    AuthFailedError,
+    ConnectionOptions,
+    HomeComAlt,
+    async_get_bacon_devices,
+)
 import voluptuous as vol
 
+from homecom_alt.const import BACON_DEFAULT_REGION, BACON_KNOWN_REGIONS
+
 from .const import (
+    CONF_BACON_REGION,
     CONF_BRAND_BUDERUS,
     CONF_DEVICES,
     CONF_REFRESH,
@@ -57,6 +66,9 @@ AUTH_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_BRAND_BUDERUS, default=False): cv.boolean,
+        vol.Required(
+            CONF_BACON_REGION, default=BACON_DEFAULT_REGION
+        ): vol.In(list(BACON_KNOWN_REGIONS)),
     }
 )
 
@@ -157,6 +169,25 @@ class BoschHomecomConfigFlow(ConfigFlow, domain=DOMAIN):
 
             if asyncio.iscoroutine(devices):
                 devices = await devices
+
+            # Also discover Matter/Bacon-commissioned devices, which are not
+            # part of the pointt gateway listing. Degrade gracefully on failure.
+            bacon_region = (self.data or {}).get(
+                CONF_BACON_REGION, BACON_DEFAULT_REGION
+            )
+            try:
+                bacon_devices = await async_get_bacon_devices(
+                    websession, bhc.token, bacon_region
+                )
+                known = {(d["deviceId"], d["deviceType"]) for d in devices}
+                for bacon_device in bacon_devices:
+                    if (
+                        bacon_device["deviceId"],
+                        bacon_device["deviceType"],
+                    ) not in known:
+                        devices.append(bacon_device)
+            except Exception:  # noqa: BLE001 - never block pointt setup
+                _LOGGER.warning("Could not fetch Bacon devices", exc_info=True)
 
             if self.data is None:
                 self.data = {}

--- a/custom_components/bosch_homecom/const.py
+++ b/custom_components/bosch_homecom/const.py
@@ -25,6 +25,7 @@ MODEL = {
     "icom": "Bosch Heat Pump",
     "rrc2": "Bosch Thermostat",
     "commodule": "Bosch EV Charger",
+    "bacon_rac": "Residential Air Conditioning (Matter)",
 }
 
 ATTR_NOTIFICATIONS = "notifications"
@@ -48,6 +49,8 @@ SINGLEKEY_LOGIN_URL_BUDERUS = "https://singlekey-id.com/auth/connect/authorize?s
 CONF_DEVICES: Final = "devices"
 CONF_REFRESH: Final = "refresh"
 CONF_WB_LABEL: Final = "wb_label"
+CONF_BACON_CLIENT_ID: Final = "bacon_client_id"
+CONF_BACON_REGION: Final = "bacon_region"
 DEFAULT_WB_LABEL: Final = "Wallbox"
 
 BOSCH_SENSOR_DESCRIPTORS = {

--- a/custom_components/bosch_homecom/coordinator.py
+++ b/custom_components/bosch_homecom/coordinator.py
@@ -3,17 +3,20 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+import asyncio
 import logging
 from typing import TypeVar
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_TOKEN
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homecom_alt import (
     ApiError,
     AuthFailedError,
+    BaconMqttClient,
+    BHCDeviceBaconRac,
     BHCDeviceCommodule,
     BHCDeviceGeneric,
     BHCDeviceIcom,
@@ -21,9 +24,12 @@ from homecom_alt import (
     BHCDeviceRac,
     BHCDeviceRrc2,
     BHCDeviceWddw2,
+    HomeComAlt,
+    HomeComBaconRac,
     HomeComRac,
     InvalidSensorDataError,
     NotRespondingError,
+    decode_jwt_sub,
 )
 from tenacity import RetryError
 
@@ -318,3 +324,133 @@ class BoschComModuleCoordinatorCommodule(
             eth0_state=data.eth0_state,
             wifi_state=data.wifi_state,
         )
+
+
+class BoschComModuleCoordinatorBaconRac(DataUpdateCoordinator[BHCDeviceBaconRac]):
+    """Coordinator for a Matter/Bacon-commissioned RAC device (MQTT shadow).
+
+    Unlike the pointt (REST) coordinators these devices push their state over an
+    MQTT device-shadow. A single :class:`BaconMqttClient` is shared across all
+    bacon devices of the entry; live shadow updates are pushed straight into the
+    coordinator, while the periodic refresh doubles as a keep-alive/reconnect and
+    handles OAuth token rotation.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        bhc: HomeComBaconRac,
+        device: dict,
+        firmware: dict,
+        entry: ConfigEntry,
+        client: BaconMqttClient,
+        token_manager: HomeComAlt,
+        lock: asyncio.Lock,
+        auth_provider: bool,
+    ) -> None:
+        """Initialize the bacon coordinator."""
+        super().__init__(
+            hass,
+            logger=_LOGGER,
+            name=DOMAIN,
+            update_interval=DEFAULT_UPDATE_INTERVAL,
+            always_update=True,
+        )
+        self.bhc = bhc
+        self.client = client
+        self.token_manager = token_manager
+        self._lock = lock
+        self.auth_provider = auth_provider
+        self.unique_id = device["deviceId"]
+        self.device = device
+        self.entry = entry
+        self.firmware = firmware["value"]
+
+        self.device_info = DeviceInfo(
+            serial_number=self.unique_id,
+            identifiers={(DOMAIN, self.unique_id)},
+            name="Boschcom_" + device["deviceType"] + "_" + device["deviceId"],
+            sw_version=self.firmware,
+            manufacturer=MANUFACTURER,
+        )
+
+        client.register_listener(self.unique_id, self._handle_push)
+
+    @callback
+    def _handle_push(self, state: dict) -> None:
+        """Push a live shadow update from MQTT into the coordinator."""
+        self.async_set_updated_data(self._build(state))
+
+    def _build(self, state: dict) -> BHCDeviceBaconRac:
+        # Shadow update/accepted messages can be partial deltas (or carry only
+        # the desired branch). Merge onto the last known state so a partial
+        # message never wipes fields such as tempSetpoint or customTitle.
+        prev = self.data
+        reported = {
+            **(prev.reported if prev and prev.reported else {}),
+            **(state.get("reported") or {}),
+        }
+        desired = {
+            **(prev.desired if prev and prev.desired else {}),
+            **(state.get("desired") or {}),
+        }
+        title = reported.get("customTitle")
+        if title:
+            clean = title.split("%|")[0].strip()
+            if clean:
+                self.device_info["name"] = clean
+        return BHCDeviceBaconRac(
+            device=self.device,
+            firmware=self.firmware,
+            reported=reported,
+            desired=desired,
+        )
+
+    async def _ensure_connected(self) -> None:
+        """Ensure the shared MQTT client is connected, refreshing the token.
+
+        Only the ``auth_provider`` coordinator rotates the OAuth token (a single
+        owner — refresh tokens are single-use). Others reuse the token persisted
+        on the config entry, which the token owner keeps fresh.
+        """
+        if self.client.is_connected:
+            return
+        async with self._lock:
+            if self.client.is_connected:
+                return
+            if self.auth_provider:
+                try:
+                    await self.token_manager.get_token()
+                except AuthFailedError as err:
+                    self.entry.async_start_reauth(self.hass)
+                    raise UpdateFailed("Re-authentication required") from err
+                if self.token_manager.token != self.entry.data.get(
+                    CONF_TOKEN
+                ) or self.token_manager.refresh_token != self.entry.data.get(
+                    CONF_REFRESH
+                ):
+                    new_data = dict(self.entry.data)
+                    new_data[CONF_TOKEN] = self.token_manager.token
+                    new_data[CONF_REFRESH] = self.token_manager.refresh_token
+                    self.hass.config_entries.async_update_entry(
+                        self.entry, data=new_data
+                    )
+                token = self.token_manager.token
+            else:
+                token = self.entry.data.get(CONF_TOKEN)
+            sub = decode_jwt_sub(token)
+            if not sub:
+                raise UpdateFailed("Could not derive user id from token")
+            await self.client.async_connect(token, sub)
+
+    async def _async_update_data(self) -> BHCDeviceBaconRac:
+        """Refresh via a shadow get (also reconnects if the session dropped)."""
+        try:
+            await self._ensure_connected()
+            state = await self.bhc.async_update()
+        except AuthFailedError as err:
+            self.entry.async_start_reauth(self.hass)
+            raise UpdateFailed("Re-authentication required") from err
+        except (ApiError, InvalidSensorDataError, NotRespondingError, TimeoutError) as err:
+            raise UpdateFailed(err) from err
+        return self._build(state)

--- a/custom_components/bosch_homecom/manifest.json
+++ b/custom_components/bosch_homecom/manifest.json
@@ -1,13 +1,20 @@
 {
   "domain": "bosch_homecom",
   "name": "Bosch HomeCom",
-  "codeowners": ["@serbanb11"],
+  "codeowners": [
+    "@serbanb11"
+  ],
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/serbanb11/bosch-homecom-hass/",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/serbanb11/bosch-homecom-hass/issues",
-  "loggers": ["custom_components.bosch_homecom", "homecom_alt"],
-  "requirements": ["homecom_alt>=1.6.7"],
-  "version": "1.3.41"
+  "loggers": [
+    "custom_components.bosch_homecom",
+    "homecom_alt"
+  ],
+  "requirements": [
+    "homecom_alt>=1.7.0"
+  ],
+  "version": "1.4.0"
 }


### PR DESCRIPTION
# Add support for Matter/"Bacon"-commissioned RAC air conditioners (cloud MQTT device-shadow)

## Problem

Bosch Climate AC units that are commissioned through the HomeCom Easy app **over Matter**
(serial numbers like `86DM-580-…`) never show up in this integration. Device discovery
reads only the pointt `/gateways/` endpoint, which returns an empty list for these units —
they are not pointt gateways. Setup therefore completes with **0 devices** and the user is
told (issue #115) to "use Matter instead". This affects the Climate 3000i/5000i/6000i family
when added via the app's Matter/BLE pairing flow.

These devices are instead managed by Bosch's **"bacon"** backend and controlled over an
AWS-IoT-style **device shadow via MQTT 5 (WebSocket)** — the same channel the official app uses.

## What this PR does

Adds a parallel discovery + control path for these devices, alongside the existing pointt
REST path (fully additive; the pointt flow is unchanged and degrades gracefully if the bacon
discovery call fails).

- **Discovery**: `GET https://claiming.euc1.bacon.bosch-tt-cw.com/v1/users/self/devices`
  returns the user's Matter device serials. They are surfaced in the config-flow device
  picker as `deviceType: "bacon_rac"`.
- **Transport**: one shared MQTT 5 / WebSocket connection per config entry to
  `wss://broker.euc1.bacon.bosch-tt-cw.com:443/mqtt`.
- **State**: read via the shadow `get` topic; live changes pushed via `update/accepted`.
- **Control**: publish `{"state":{"desired":{…}}}` to the shadow `update` topic.
- **Entity**: a `climate` entity per unit (power, hvac mode, target temperature, fan speed, swing).

## Reverse-engineered protocol (verified live)

- ClientID **must** be a 64-char lowercase hex string (otherwise CONNACK `Not authorized`).
- WebSocket upgrade headers: `Authorization: Bearer <accessToken>` and
  `User-Agent: DashApp/<ver> (Android-Release)`.
- MQTT CONNECT: username = the JWT `sub` claim, password = the raw access token
  (the same SingleKey OIDC token already managed by this integration; scope must include `bacon`).
- Topics: `users/{sub}/devices/{serial}/shadows/state/{get|update}[/accepted|/rejected]`.
- RAC shadow fields: `powerEnabled`, `opMode` (`cool|heat|auto|dry|fan`),
  `fanSpeed` (`auto|quiet|low|medium|high|turbo`), `tempSetpoint` (°C int),
  `hSwingEnabled`, `vSwingEnabled`, plus `fullPowerEnabled`/`sleepEnabled`/`ionizerEnabled`/…
  `reported.customTitle` carries the friendly name.

## Files

**`homecom_alt` (library, bumped to 1.7.0):**
- `bacon.py` (new): `async_get_bacon_devices`, `BaconMqttClient`, `HomeComBaconRac`, `decode_jwt_sub`, `generate_client_id`.
- `const.py`: bacon broker/claim/topic constants.
- `model.py`: `BHCDeviceBaconRac`.
- `pyproject.toml`: `paho-mqtt>=2.0` dependency.
- `tests/test_bacon.py`.

**`bosch-homecom-hass` (integration, bumped to 1.4.0):**
- `config_flow.py`: merge bacon devices into discovery.
- `__init__.py`: shared `BaconMqttClient`, one coordinator per bacon device.
- `coordinator.py`: `BoschComModuleCoordinatorBaconRac` (MQTT push + periodic keep-alive/reconnect + single-owner token rotation).
- `climate.py`: `BoschComBaconRacClimate`.
- `const.py`: `bacon_rac` model label, `CONF_BACON_CLIENT_ID`.
- `manifest.json`: requirement `homecom_alt>=1.7.0`.

## Notes / limitations

- Only RAC (air conditioners) is implemented so far. The bacon backend also serves DHW and
  air-purifier shadows with the same transport; those can follow.
- Token ownership: refresh tokens are single-use, so exactly one coordinator "owns" the
  refresh (the pointt auth-provider if present, otherwise the first bacon coordinator);
  the rest reuse the token persisted on the config entry.
- A stable 64-hex `client_id` is generated once and persisted on the entry so the HA
  connection never collides with the phone app's client id.
