### PR TITLE
Fix UnboundLocalError in DHW/HC select entities

### DIFF
--- a/custom_components/bosch_homecom/select.py
+++ b/custom_components/bosch_homecom/select.py
@@ -620,6 +620,8 @@ class BoschComSelectDhwCurrentTemp(CoordinatorEntity, SelectEntity):
             value = data.get(key)
             return value if value is not None else default
 
+        currentTemperatureLevel = None
+
         for entry in self.coordinator.data.dhw_circuits:
             if entry.get("id") == "/dhwCircuits/" + self.field:
                 currentTemperatureLevel = safe_get(
@@ -636,6 +638,8 @@ class BoschComSelectDhwCurrentTemp(CoordinatorEntity, SelectEntity):
             """Return unknown if null."""
             value = data.get(key)
             return value if value is not None else default
+
+        currentTemperatureLevel = None
 
         for entry in self.coordinator.data.dhw_circuits:
             if entry.get("id") == "/dhwCircuits/" + self.field:
@@ -754,6 +758,8 @@ class BoschComSelectHcSuwiMode(CoordinatorEntity, SelectEntity):
             value = data.get(key)
             return value if value is not None else default
 
+        currentSuWiMode = None
+
         for entry in self.coordinator.data.heating_circuits:
             if entry.get("id") == "/heatingCircuits/" + self.field:
                 currentSuWiMode = safe_get(entry["currentSuWiMode"], "value")
@@ -768,6 +774,8 @@ class BoschComSelectHcSuwiMode(CoordinatorEntity, SelectEntity):
             """Return unknown if null."""
             value = data.get(key)
             return value if value is not None else default
+
+        currentSuWiMode = None
 
         for entry in self.coordinator.data.heating_circuits:
             if entry.get("id") == "/heatingCircuits/" + self.field:
@@ -817,6 +825,8 @@ class BoschComSelectHcHeatcoolMode(CoordinatorEntity, SelectEntity):
             value = data.get(key)
             return value if value is not None else default
 
+        heatCoolMode = None
+
         for entry in self.coordinator.data.heating_circuits:
             if entry.get("id") == "/heatingCircuits/" + self.field:
                 heatCoolMode = safe_get(entry["heatCoolMode"], "value")
@@ -831,6 +841,8 @@ class BoschComSelectHcHeatcoolMode(CoordinatorEntity, SelectEntity):
             """Return unknown if null."""
             value = data.get(key)
             return value if value is not None else default
+
+        heatCoolMode = None
 
         for entry in self.coordinator.data.heating_circuits:
             if entry.get("id") == "/heatingCircuits/" + self.field:


### PR DESCRIPTION
### Problem

Three select entity classes assign their state variable **only inside** the `for entry in ...` loop. If no circuit matches `self.field`, the loop body never executes and the following read raises:

```
File "/config/custom_components/bosch_homecom/select.py", line 646, in _handle_coordinator_update
    self._attr_current_option = currentTemperatureLevel
UnboundLocalError: cannot access local variable 'currentTemperatureLevel' where it is not associated with a value
```

Because this happens in `_handle_coordinator_update`, it fires on **every** coordinator update and the affected entities stop updating their state entirely. On my K40 setup (HA 2026.8.0, bosch_homecom 1.4.2 and 1.4.3) this logs several times a day.

### Affected

| Class | Variable |
|---|---|
| `BoschComSelectDhwCurrentTemp` | `currentTemperatureLevel` |
| `BoschComSelectHcSuwiMode` | `currentSuWiMode` |
| `BoschComSelectHcHeatcoolMode` | `heatCoolMode` |

Each in both `current_option` and `_handle_coordinator_update` — six sites total.

### Fix

Initialize the variable to `None` before the loop. This is exactly what the neighbouring classes already do — `BoschComSelectDhwOperationMode`, `BoschComSelectHcOperationMode` and `BoschComSelectHcCoolingOperationMode` all carry a `... = None` above their loop — so the three classes above look like an oversight rather than a deliberate difference.

Behaviour is unchanged whenever a circuit does match; `current_option` returning `None` is already covered by the declared `str | None` return type.