### PR TITLE
fix(icom): cooling mode bypasses temporaryRoomSetpoint for HC set_temperature

### DIFF
--- a/custom_components/bosch_homecom/climate.py
+++ b/custom_components/bosch_homecom/climate.py
@@ -368,16 +368,17 @@ class BoschComK40Climate(CoordinatorEntity, ClimateEntity):
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
             return
 
-        if isinstance(self.coordinator, BoschComModuleCoordinatorIcom):
-            # icom: use temporaryRoomSetpoint to match the Bosch app behaviour
-            await self.coordinator.async_set_temporary_room_setpoint(
-                self.field, temperature
-            )
-        elif self._is_cooling():
-            # In cooling mode the manualRoomSetpoint endpoint returns 404;
+        if self._is_cooling():
+            # Cooling mode takes priority for all device types — in cooling the
+            # manualRoomSetpoint and temporaryRoomSetpoint endpoints return 404;
             # the writable setpoint is coolingRoomTempSetpoint instead.
             await self.coordinator.bhc.async_set_hc_cooling_room_temp_setpoint(
                 self.coordinator.unique_id, self.field, temperature
+            )
+        elif isinstance(self.coordinator, BoschComModuleCoordinatorIcom):
+            # icom (non-cooling): use temporaryRoomSetpoint to match the Bosch app behaviour
+            await self.coordinator.async_set_temporary_room_setpoint(
+                self.field, temperature
             )
         else:
             await self.coordinator.bhc.async_set_hc_manual_room_setpoint(


### PR DESCRIPTION
## Summary

- When an icom heating circuit is in cooling mode (`currentSuWiMode = "cooling"`), the `temporaryRoomSetpoint` endpoint returns 404 — the correct write path is `coolingRoomTempSetpoint`.
- The previous condition order in `BoschComK40Climate.async_set_temperature` checked `isinstance(coordinator, BoschComModuleCoordinatorIcom)` **before** `_is_cooling()`, so icom circuits always used `temporaryRoomSetpoint`, even when in cooling mode.
- Result: setting the target temperature on an icom HC in cooling mode silently failed (API 404).

**Fix:** Move the `_is_cooling()` branch first — it applies to both icom and k40 devices. The icom-specific `temporaryRoomSetpoint` path now only runs for non-cooling circuits.

This bug was introduced in #131 (merged in v1.3.39). The fix was found by a user with a Bosch Compress 7001i AW with HC2 in cooling season.

## Test plan

- [ ] icom HC in cooling mode → `coolingRoomTempSetpoint` is called, temperature change applied
- [ ] icom HC in heating mode → `temporaryRoomSetpoint` is called (unchanged behaviour)
- [ ] k40/k30 HC in cooling mode → `coolingRoomTempSetpoint` is called (unchanged behaviour)
- [ ] k40/k30 HC in heating mode → `manualRoomSetpoint` is called (unchanged behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)