### PR TITLE
feat: expose solar thermal circuits as sensors

### DIFF
--- a/custom_components/bosch_homecom/coordinator.py
+++ b/custom_components/bosch_homecom/coordinator.py
@@ -381,6 +381,10 @@ class BoschComModuleCoordinatorK40(
         }
         if "pool" in BHCDeviceK40.__dataclass_fields__:
             kwargs["pool"] = getattr(data, "pool", None)
+        # Solar thermal circuits: added in homecom_alt after the pinned minimum,
+        # so probe the dataclass the same way as pool to stay compatible.
+        if "solar_circuits" in BHCDeviceK40.__dataclass_fields__:
+            kwargs["solar_circuits"] = getattr(data, "solar_circuits", None)
         return BHCDeviceK40(**kwargs)
 
 

--- a/custom_components/bosch_homecom/sensor.py
+++ b/custom_components/bosch_homecom/sensor.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 import json
 import logging
 import re
-from typing import Any, Optional
+from typing import Any, Final, Optional
 
 from homeassistant import config_entries, core
 from homeassistant.components.binary_sensor import BinarySensorEntity
@@ -130,6 +130,19 @@ async def async_setup_entry(
                     BoschComSensorHc(
                         coordinator=coordinator, config_entry=config_entry, field=hc_id
                     )
+                )
+            # Solar thermal circuits (only present with a collector installed)
+            for ref in getattr(coordinator.data, "solar_circuits", None) or []:
+                solar_id = ref["id"].split("/")[-1]
+                entities.extend(
+                    BoschComSensorSolarCircuit(
+                        coordinator=coordinator,
+                        config_entry=config_entry,
+                        circuit_id=solar_id,
+                        key=key,
+                    )
+                    for key in SOLAR_CIRCUIT_SENSORS
+                    if key in ref
                 )
             # Heat source
             entities.append(
@@ -1143,6 +1156,96 @@ class BoschComSensorPoolTemp(BoschComSensorBase):
             return float(value)
         except (TypeError, ValueError):
             return None
+
+
+SOLAR_CIRCUIT_SENSORS: Final[dict[str, dict[str, Any]]] = {
+    "collectorTemperature": {
+        "translation_key": "solar_collector_temperature",
+        "icon": "mdi:solar-panel",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfTemperature.CELSIUS,
+    },
+    "solarYield": {
+        "translation_key": "solar_yield",
+        "icon": "mdi:solar-power-variant",
+        "device_class": SensorDeviceClass.ENERGY,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "unit": UnitOfEnergy.KILO_WATT_HOUR,
+    },
+    "dhwTankTemperature": {
+        "translation_key": "solar_tank_temperature",
+        "icon": "mdi:water-thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfTemperature.CELSIUS,
+    },
+    "dhwTankBottomTemperature": {
+        "translation_key": "solar_tank_bottom_temperature",
+        "icon": "mdi:water-thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfTemperature.CELSIUS,
+    },
+    "maxCylinderTemperature": {
+        "translation_key": "solar_max_cylinder_temperature",
+        "icon": "mdi:thermometer-alert",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfTemperature.CELSIUS,
+    },
+}
+
+
+class BoschComSensorSolarCircuit(BoschComSensorBase):
+    """A single value of a solar thermal circuit."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: BoschComModuleCoordinatorK40,
+        config_entry: config_entries.ConfigEntry,
+        circuit_id: str,
+        key: str,
+    ) -> None:
+        """Initialize a solar circuit sensor."""
+        spec = SOLAR_CIRCUIT_SENSORS[key]
+        field = f"{circuit_id}_{key}"
+        super().__init__(
+            coordinator=coordinator,
+            config_entry=config_entry,
+            unique_id=f"{coordinator.unique_id}-{field}-sensor",
+            icon=spec["icon"],
+        )
+        self._attr_device_class = spec["device_class"]
+        self._attr_state_class = spec["state_class"]
+        self._attr_native_unit_of_measurement = spec["unit"]
+        self._attr_translation_key = spec["translation_key"]
+        self._attr_translation_placeholders = {"circuit": circuit_id}
+        self._attr_unique_id = f"{coordinator.unique_id}-{field}"
+        self._attr_suggested_object_id = field + "_sensor"
+        self._attr_should_poll = False
+        self.circuit_id = circuit_id
+        self.key = key
+
+    @property
+    def state(self):
+        """Return the value of this solar circuit reading."""
+        for entry in getattr(self.coordinator.data, "solar_circuits", None) or []:
+            if entry.get("id") != "/solarCircuits/" + self.circuit_id:
+                continue
+            reading = entry.get(self.key) or {}
+            if reading.get("unitOfMeasure") == "F":
+                self._attr_native_unit_of_measurement = UnitOfTemperature.FAHRENHEIT
+            value = reading.get("value")
+            if value is None:
+                return None
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                return None
+        return None
 
 
 class BoschComSensorHs(BoschComSensorBase):

--- a/custom_components/bosch_homecom/strings.json
+++ b/custom_components/bosch_homecom/strings.json
@@ -457,6 +457,21 @@
       },
       "bacon_signal_quality": {
         "name": "Signal quality"
+      },
+      "solar_collector_temperature": {
+        "name": "{circuit} collector temperature"
+      },
+      "solar_yield": {
+        "name": "{circuit} solar yield"
+      },
+      "solar_tank_temperature": {
+        "name": "{circuit} tank temperature"
+      },
+      "solar_tank_bottom_temperature": {
+        "name": "{circuit} tank bottom temperature"
+      },
+      "solar_max_cylinder_temperature": {
+        "name": "{circuit} max cylinder temperature"
       }
     },
     "binary_sensor": {

--- a/custom_components/bosch_homecom/translations/de.json
+++ b/custom_components/bosch_homecom/translations/de.json
@@ -458,6 +458,21 @@
       },
       "bacon_signal_quality": {
         "name": "Signalqualität"
+      },
+      "solar_collector_temperature": {
+        "name": "{circuit} Kollektortemperatur"
+      },
+      "solar_yield": {
+        "name": "{circuit} Solarertrag"
+      },
+      "solar_tank_temperature": {
+        "name": "{circuit} Speichertemperatur"
+      },
+      "solar_tank_bottom_temperature": {
+        "name": "{circuit} Speichertemperatur unten"
+      },
+      "solar_max_cylinder_temperature": {
+        "name": "{circuit} max. Speichertemperatur"
       }
     },
     "binary_sensor": {

--- a/custom_components/bosch_homecom/translations/en.json
+++ b/custom_components/bosch_homecom/translations/en.json
@@ -456,6 +456,21 @@
       },
       "bacon_signal_quality": {
         "name": "Signal quality"
+      },
+      "solar_collector_temperature": {
+        "name": "{circuit} collector temperature"
+      },
+      "solar_yield": {
+        "name": "{circuit} solar yield"
+      },
+      "solar_tank_temperature": {
+        "name": "{circuit} tank temperature"
+      },
+      "solar_tank_bottom_temperature": {
+        "name": "{circuit} tank bottom temperature"
+      },
+      "solar_max_cylinder_temperature": {
+        "name": "{circuit} max cylinder temperature"
       }
     },
     "binary_sensor": {

--- a/custom_components/bosch_homecom/translations/nl.json
+++ b/custom_components/bosch_homecom/translations/nl.json
@@ -456,6 +456,21 @@
       },
       "bacon_signal_quality": {
         "name": "Signaalkwaliteit"
+      },
+      "solar_collector_temperature": {
+        "name": "{circuit} collectortemperatuur"
+      },
+      "solar_yield": {
+        "name": "{circuit} zonneopbrengst"
+      },
+      "solar_tank_temperature": {
+        "name": "{circuit} boilertemperatuur"
+      },
+      "solar_tank_bottom_temperature": {
+        "name": "{circuit} boilertemperatuur onder"
+      },
+      "solar_max_cylinder_temperature": {
+        "name": "{circuit} max. boilertemperatuur"
       }
     },
     "binary_sensor": {

--- a/tests/test_solar.py
+++ b/tests/test_solar.py
@@ -1,0 +1,116 @@
+"""Tests for the solar thermal circuit sensors (K30/K40/icom)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.bosch_homecom.sensor import (
+    SOLAR_CIRCUIT_SENSORS,
+    BoschComSensorSolarCircuit,
+)
+
+SAMPLE_SOLAR_CIRCUITS = [
+    {
+        "id": "/solarCircuits/sc1",
+        "collectorTemperature": {"value": 68.4, "unitOfMeasure": "C"},
+        "solarYield": {"value": 123, "unitOfMeasure": "kWh"},
+        "dhwTankTemperature": {"value": 55.1, "unitOfMeasure": "C"},
+        "dhwTankBottomTemperature": {"value": 41.2, "unitOfMeasure": "C"},
+        "maxCylinderTemperature": {"value": 80, "unitOfMeasure": "C"},
+    }
+]
+
+
+def _mock_coordinator(solar_circuits=SAMPLE_SOLAR_CIRCUITS):
+    """Build a mock coordinator exposing coordinator.data.solar_circuits."""
+
+    class _Data:
+        def __init__(self, circuits):
+            self.solar_circuits = circuits
+            self.device = {"deviceId": "102128202", "deviceType": "k40"}
+
+    coordinator = MagicMock()
+    coordinator.unique_id = "102128202"
+    coordinator.device_info = {"identifiers": {("bosch_homecom", "102128202")}}
+    coordinator.data = _Data(solar_circuits)
+    return coordinator
+
+
+def _sensor(key, coordinator=None, circuit_id="sc1"):
+    return BoschComSensorSolarCircuit(
+        coordinator=coordinator or _mock_coordinator(),
+        config_entry=None,
+        circuit_id=circuit_id,
+        key=key,
+    )
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("collectorTemperature", 68.4),
+        ("solarYield", 123.0),
+        ("dhwTankTemperature", 55.1),
+        ("dhwTankBottomTemperature", 41.2),
+        ("maxCylinderTemperature", 80.0),
+    ],
+)
+def test_solar_sensor_reports_value(key, expected) -> None:
+    """Every solar reading is exposed as its numeric value."""
+    assert _sensor(key).state == expected
+
+
+def test_solar_sensor_unique_id_and_translation_key() -> None:
+    """Unique ids are namespaced per circuit and reading."""
+    sensor = _sensor("collectorTemperature")
+    assert sensor.unique_id == "102128202-sc1_collectorTemperature"
+    assert sensor.translation_key == "solar_collector_temperature"
+    assert sensor.translation_placeholders == {"circuit": "sc1"}
+
+
+def test_solar_sensor_without_circuits() -> None:
+    """No circuits at all yields None rather than raising."""
+    assert _sensor("collectorTemperature", _mock_coordinator([])).state is None
+
+
+def test_solar_sensor_unknown_circuit() -> None:
+    """A reading for a circuit that is not reported yields None."""
+    sensor = _sensor("collectorTemperature", circuit_id="sc9")
+    assert sensor.state is None
+
+
+def test_solar_sensor_missing_reading() -> None:
+    """A circuit missing this particular reading yields None."""
+    coordinator = _mock_coordinator([{"id": "/solarCircuits/sc1"}])
+    assert _sensor("collectorTemperature", coordinator).state is None
+
+
+def test_solar_sensor_non_numeric_value() -> None:
+    """A non-numeric payload yields None instead of raising."""
+    coordinator = _mock_coordinator(
+        [{"id": "/solarCircuits/sc1", "collectorTemperature": {"value": "n/a"}}]
+    )
+    assert _sensor("collectorTemperature", coordinator).state is None
+
+
+def test_solar_sensor_fahrenheit_unit() -> None:
+    """The reported unit follows unitOfMeasure when the system uses Fahrenheit."""
+    coordinator = _mock_coordinator(
+        [
+            {
+                "id": "/solarCircuits/sc1",
+                "collectorTemperature": {"value": 155.1, "unitOfMeasure": "F"},
+            }
+        ]
+    )
+    sensor = _sensor("collectorTemperature", coordinator)
+    assert sensor.state == 155.1
+    assert sensor.native_unit_of_measurement == "°F"
+
+
+def test_every_declared_sensor_is_translatable() -> None:
+    """Each declared reading carries a translation key."""
+    for spec in SOLAR_CIRCUIT_SENSORS.values():
+        assert spec["translation_key"].startswith("solar_")


### PR DESCRIPTION
Closes #177. Follow-up to serbanb11/homecom_alt#121, which you merged — thanks for that.

That PR makes K30/K40 request `/solarCircuits` and resolve the per-circuit values. This one consumes them. Worth noting the second half of #177: **nothing consumed `solar_circuits` for any device type**, so even icom users had the data fetched and then dropped. This covers icom too.

## Changes

**`coordinator.py`** — pass `solar_circuits` through in `BoschComModuleCoordinatorK40._build_device_data`, probing `BHCDeviceK40.__dataclass_fields__` exactly as `pool` already does, so the integration keeps working against a `homecom_alt` that predates the field.

**`sensor.py`** — `BoschComSensorSolarCircuit`, one entity per reading per circuit, driven by a `SOLAR_CIRCUIT_SENSORS` table:

| reading | device class | state class |
|---|---|---|
| `collectorTemperature` | temperature | measurement |
| `solarYield` | energy | total_increasing |
| `dhwTankTemperature` | temperature | measurement |
| `dhwTankBottomTemperature` | temperature | measurement |
| `maxCylinderTemperature` | temperature | measurement |

Registered in the shared `k40/k30/icom` branch, guarded with `getattr(..., "solar_circuits", None) or []`, and only for readings the device actually reports (`if key in ref`) — so a system without a collector gets no entities, and a partial payload does not produce dead ones. `solarYield` is `total_increasing` so it can go straight into the energy dashboard. `unitOfMeasure == "F"` switches the unit, matching `BoschComSensorDhw`.

**Translations** — `en`, `de`, `nl`, plus `strings.json`.

## Verification

- `flake8 custom_components` — clean
- `isort --check-only` / `black --check` — clean
- `mypy custom_components tests` — **Success, 31 source files**
- `tests/test_solar.py` — **12 passed** (values, unique id and translation key, no circuits, unknown circuit, missing reading, non-numeric payload, Fahrenheit)
- `tests/test_translations.py` — **9 passed**, which is the check that matters for the new translation keys

One caveat I want to be straight about: I could not run the **full** suite locally. `requirements.test.txt` resolved `pytest-homeassistant-custom-component` down to `0.13.236` / HA `2025.4.4` in my environment, and `config_flow.py` needs `OptionsFlowWithReload` from a newer core, so `conftest.py` fails to import before any test runs. That is my environment, not this branch — the tests above were run with `--noconftest`, and CI on 3.13 should resolve properly. Please do re-run `tox` on your side.

Also not yet exercised against live hardware: my own collector is behind a K40 and I will confirm real readings as soon as there is a `homecom_alt` release containing #121 — happy to report back here before you merge if you would rather wait for that.